### PR TITLE
added get_references_of to DAOModel

### DIFF
--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -78,11 +78,20 @@ class DAOModel(SQLModel):
     @classmethod
     def get_fk_properties(cls) -> set[Column]:
         """
-        Returns the Columns that represent Foreign Keys for this Model.
+        Returns the Columns of this Model that represent Foreign Keys.
 
         :return: An unordered set of foreign key columns
         """
         return {fk.parent for fk in cls.__table__.foreign_keys}
+
+    @classmethod
+    def get_references_of(cls, model: Self) -> set[Column]:
+        """
+        Returns the Columns of this Model that represent Foreign Keys of the specified Model.
+
+        :return: An unordered set of foreign key columns
+        """
+        return {fk.parent for fk in cls.__table__.foreign_keys if model.has_column(fk.column)}
 
     @classmethod
     def get_properties(cls) -> Iterable[Column]:

--- a/tests/labeled_tests.py
+++ b/tests/labeled_tests.py
@@ -1,0 +1,17 @@
+import inspect
+from typing import Callable, Union, Any
+
+import pytest
+
+
+def labeled_tests(test_case_data: dict[str, Union[tuple[Any, ...], list[tuple[Any, ...]]]]):
+    def decorator(test_func: Callable):
+        params = ", ".join(inspect.signature(test_func).parameters.keys())
+        labels = []
+        test_data = []
+        for key, value in test_case_data.items():
+            for data in value if isinstance(value, list) else [value]:
+                labels.append(key)
+                test_data.append(data)
+        return pytest.mark.parametrize(params, test_data, ids=labels)(test_func)
+    return decorator


### PR DESCRIPTION
Added functionality to provide a DAOModel (to another DAOModel) and get all of the foreign key properties that reference said model. This is in addition to the get_fk and get_fk_properties functions but limits to only targeted foreign keys.

For testing, a test utility decorator (labeled_tests) was created to allow written tests to define in-line labels. This allows grouping of tests and giving them meaningful categories while avoiding duplicating logic within multiple individual tests. This will clean up the test classes while keeping important distinctions between test cases.