### PR TITLE
Get property names

### DIFF
--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -4,7 +4,10 @@ from sqlalchemy import Column, Engine, inspect
 from str_case_util import Case
 from sqlalchemy.ext.declarative import declared_attr
 
-from daomodel.util import reference_of, names_of
+from daomodel.util import reference_of, names_of, in_order
+
+
+property_categories = ['all', 'pk', 'fk', 'standard', 'unset', 'defaults', 'none']
 
 
 class DAOModel(SQLModel):

--- a/daomodel/util.py
+++ b/daomodel/util.py
@@ -82,6 +82,20 @@ def dedupe(original: list) -> list:
     return list(OrderedDict.fromkeys(original))
 
 
+def in_order(original: Iterable, order: list) -> list:
+    """Returns provided items as an ordered list.
+
+    Repeated items will be deduplicated.
+    Items not defined within the order will be excluded.
+    The order is allowed to contain extraneous items that aren't applicable to the provided items.
+
+    :param original: The (likely unordered) collection of items
+    :param order: The defined order of items
+    :return: a new list of the items following the defined order
+    """
+    return [item for item in order if item in original]
+
+
 def next_id() -> None:
     """Indicates to the model that an id should be auto incremented"""
     return None

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -36,7 +36,7 @@ class ComplicatedModel(BaseModel, table=True):
     fkB: int = Field(foreign_key='foreign_key_model.pkB')
 
     @classmethod
-    def get_searchable_properties(cls) -> set[Column|tuple[DAOModel, ..., Column]]:
+    def get_searchable_properties(cls) -> set[Column|tuple[type[DAOModel], ..., Column]]:
         return {cls.pkC, cls.pkD, cls.prop1, cls.fkA, cls.fkB, ForeignKEYModel.prop, (ForeignKEYModel, SimpleModel.pkA)}
 
 complicated_instance = ComplicatedModel(pkC=17, pkD=76, prop1='prop', prop2='erty', fkA=23, fkB=32)

--- a/tests/test_get_property_names.py
+++ b/tests/test_get_property_names.py
@@ -1,0 +1,203 @@
+from typing import Optional
+
+from sqlmodel import Field
+
+from daomodel import DAOModel
+from tests.labeled_tests import labeled_tests
+
+
+class ForeignModel(DAOModel, table=True):
+    pk: int = Field(primary_key=True)
+
+
+class PropertyModel(DAOModel, table=True):
+    set_pk: int = Field(primary_key=True)
+    unset_pk: Optional[int] = Field(primary_key=True)
+    default_pk: Optional[int] = Field(primary_key=True, default=0)
+    set_default_pk: Optional[int] = Field(primary_key=True, default=0)
+    default_none_pk: Optional[int] = Field(primary_key=True, default=None)
+    set_none_pk: Optional[int] = Field(primary_key=True)
+    set_default_none_pk: Optional[int] = Field(primary_key=True, default=None)
+    set_fk: int = Field(foreign_key='foreign_model.pk')
+    unset_fk: Optional[int] = Field(foreign_key='foreign_model.pk')
+    default_fk: Optional[int] = Field(foreign_key='foreign_model.pk', default=0)
+    set_default_fk: Optional[int] = Field(foreign_key='foreign_model.pk', default=0)
+    default_none_fk: Optional[int] = Field(foreign_key='foreign_model.pk', default=None)
+    set_none_fk: Optional[int] = Field(foreign_key='foreign_model.pk')
+    set_default_none_fk: Optional[int] = Field(foreign_key='foreign_model.pk', default=None)
+    set: int
+    unset: Optional[int]
+    default: Optional[int] = 0
+    set_default: Optional[int] = 0
+    default_none: Optional[int] = None
+    set_none: Optional[int]
+    set_default_none: Optional[int] = None
+property_model = PropertyModel(set_pk=1, set_default_pk=0, set_none_pk=None, set_default_none_pk=None,
+                       set_fk=1, set_default_fk=0, set_none_fk=None, set_default_none_fk=None,
+                       set=1, set_default=0, set_none=None, set_default_none=None)
+
+all_properties = [
+    'set_pk',
+    'unset_pk',
+    'default_pk',
+    'set_default_pk',
+    'default_none_pk',
+    'set_none_pk',
+    'set_default_none_pk',
+    'set_fk',
+    'unset_fk',
+    'default_fk',
+    'set_default_fk',
+    'default_none_fk',
+    'set_none_fk',
+    'set_default_none_fk',
+    'set',
+    'unset',
+    'default',
+    'set_default',
+    'default_none',
+    'set_none',
+    'set_default_none'
+]
+pk_properties = [
+    'set_pk',
+    'unset_pk',
+    'default_pk',
+    'set_default_pk',
+    'default_none_pk',
+    'set_none_pk',
+    'set_default_none_pk'
+]
+fk_properties = [
+    'set_fk',
+    'unset_fk',
+    'default_fk',
+    'set_default_fk',
+    'default_none_fk',
+    'set_none_fk',
+    'set_default_none_fk'
+]
+standard_properties = [
+    'set',
+    'unset',
+    'default',
+    'set_default',
+    'default_none',
+    'set_none',
+    'set_default_none'
+]
+unset_properties = [
+    'unset_pk',
+    'default_pk',
+    'default_none_pk',
+    'unset_fk',
+    'default_fk',
+    'default_none_fk',
+    'unset',
+    'default',
+    'default_none'
+]
+default_value_properties = [
+    'unset_pk',
+    'default_pk',
+    'set_default_pk',
+    'default_none_pk',
+    'set_default_none_pk',
+    'unset_fk',
+    'default_fk',
+    'set_default_fk',
+    'default_none_fk',
+    'set_default_none_fk',
+    'unset',
+    'default',
+    'set_default',
+    'default_none',
+    'set_default_none'
+]
+none_value_properties = [
+    'unset_pk',
+    'default_none_pk',
+    'set_none_pk',
+    'set_default_none_pk',
+    'unset_fk',
+    'default_none_fk',
+    'set_none_fk',
+    'set_default_none_fk',
+    'unset',
+    'default_none',
+    'set_none',
+    'set_default_none'
+]
+set_none_value_properties = [
+    'set_none_pk',
+    'set_default_none_pk',
+    'set_none_fk',
+    'set_default_none_fk',
+    'set_none',
+    'set_default_none'
+]
+set_to_non_none_default_properties = [
+    'set_default_pk',
+    'set_default_fk',
+    'set_default'
+]
+standard_non_none_properties = [
+    'set',
+    'default',
+    'set_default'
+]
+primary_key_and_unset_foreign_key_properties = [
+    'set_pk',
+    'unset_pk',
+    'default_pk',
+    'set_default_pk',
+    'default_none_pk',
+    'set_none_pk',
+    'set_default_none_pk',
+    'unset_fk',
+    'default_fk',
+    'default_none_fk'
+]
+
+
+@labeled_tests({
+    'no properties': [
+        ({}, []),
+        ({'all': False}, []),
+        ({'pk': False}, []),
+        ({'unset': False}, []),
+        ({'defaults': False}, []),
+        ({'none': False}, []),
+        ({'pk': False, 'unset': False, 'defaults': False, 'none': False}, [])
+    ],
+    'all properties': [
+        ({'all': True}, all_properties),
+        ({'pk': True, 'fk': True, 'standard': True}, all_properties)
+    ],
+    'primary key properties': [
+        ({'pk': True}, pk_properties),
+        ({'all': True, 'fk': False, 'standard': False}, pk_properties)
+    ],
+    'foreign key properties': [
+        ({'fk': True}, fk_properties),
+        ({'all': True, 'pk': False, 'standard': False}, fk_properties)
+    ],
+    'standard properties': [
+        ({'standard': True}, standard_properties),
+        ({'all': True, 'pk': False, 'fk': False}, standard_properties)
+    ],
+    'unset properties':
+        ({'unset': True}, unset_properties),
+    'default value properties':
+        ({'defaults': True}, default_value_properties),
+    'none value properties':
+        ({'none': True}, none_value_properties),
+    'mixed property categories': [
+        ({'none': True, 'unset': False}, set_none_value_properties),
+        ({'defaults': True, 'unset': False, 'none': False}, set_to_non_none_default_properties),
+        ({'standard': True, 'none': False}, standard_non_none_properties),
+        ({'unset': True, 'standard': False, 'pk': True}, primary_key_and_unset_foreign_key_properties),
+    ]
+})
+def test_get_property_names(property_modifications: dict[str, bool], expected: list[str]):
+    assert property_model.get_property_names(**property_modifications) == expected


### PR DESCRIPTION
Added functionality to the DAOModel to allow easily getting a list of property names. These property names can be filtered by various categories including pk, fk, unset, defaults, etc. This is to support merging and renaming rows, allowing us to discover which data should be saved or overridden.