### PR TITLE
Add BaseService and complete model comparison and merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This is most useful when conducting batch actions, or when you may wish to abort
 
 ### Copying values
 Values (other than the primary key) can be copied from one model instance to another.
-This is done through `model.copy_model(other_model)` or `model.copy_values(**dictionary)`.
+This is done through `model.copy_model(other_model)` or `model.set_values(**dictionary)`.
 Both the `create` and `get` functionality have copying built-in in the form of `create_with` and `get_with`.
 ```python
 # create a new row but also populate the name column in the same line

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -301,6 +301,7 @@ def all_models(bind: Union[Engine, Connection]) -> set[type[DAOModel]]:
 
 
 PrimaryKey = Field(primary_key=True)
+OptionalPrimaryKey = Field(primary_key=True, default=None)
 
 
 def PrimaryForeignKey(foreign_property: str) -> Field:

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -2,7 +2,7 @@ from typing import Any, Self, Iterable, Union, Optional
 
 import sqlalchemy
 from sqlmodel import SQLModel, Field
-from sqlalchemy import Column, Engine, inspect
+from sqlalchemy import Column, Engine, MetaData, Connection
 from str_case_util import Case
 from sqlalchemy.ext.declarative import declared_attr
 
@@ -247,11 +247,11 @@ class Unsearchable(Exception):
         self.detail = f"Cannot search for {prop} of {model.doc_name()}"
 
 
-def all_models(engine: Engine) -> set[DAOModel]:
+def all_models(bind: Union[Engine, Connection]) -> set[type[DAOModel]]:
     """
     Discovers all DAOModel types that have been created for the database.
 
-    :param engine: The engine used to create the DB
+    :param bind: The Engine or Connection for the DB
     :return: A set of applicable DAOModels
     """
     def daomodel_subclasses(cls):
@@ -261,7 +261,9 @@ def all_models(engine: Engine) -> set[DAOModel]:
             subclasses.update(daomodel_subclasses(subclass))
         return subclasses
 
-    db_tables = set(inspect(engine).get_table_names())
+    metadata = MetaData()
+    metadata.reflect(bind=bind)
+    db_tables = metadata.tables.keys()
     return {model for model in daomodel_subclasses(DAOModel) if model.__tablename__ in db_tables}
 
 

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -162,6 +162,24 @@ class DAOModel(SQLModel):
             result = result.union(props) if value else result.difference(props)
         return in_order(result, property_order)
 
+    def compare(self, other, include_pk: Optional[bool] = False) -> dict[str, tuple[Any, Any]]:
+        """Compares this model to another, producing a diff.
+
+        By default, primary keys are excluded in the diff.
+        While designed to compare like models, it should work between different model types. Though that is untested.
+
+        :param other: The model to compare to this one
+        :param include_pk: True if you want to include the primary key in the diff
+        :return: A dictionary of property names with a tuple of this instances value and the other value respectively
+        """
+        source_values = self.model_dump(exclude=set([] if include_pk else self.get_pk_names()))
+        other_values = other.model_dump(exclude=set([] if include_pk else other.get_pk_names()))
+        diff = {}
+        for k, v in source_values.items():
+            if other_values[k] != v:
+                diff[k] = (v, other_values[k])
+        return diff
+
     @classmethod
     def get_searchable_properties(cls) -> Iterable[Column|tuple[type[Self], ..., Column]]:
         """

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from daomodel.util import reference_of, names_of, in_order, retain_in_dict, remove_from_dict
 
 
-property_categories = ['all', 'pk', 'fk', 'standard', 'assigned', 'unset', 'defaults', 'none']
+property_categories = ['all', 'pk', 'fk', 'standard', 'assigned', 'defaults', 'none']
 
 
 class DAOModel(SQLModel):
@@ -123,10 +123,9 @@ class DAOModel(SQLModel):
             pk: Primary Key properties
             fk: Foreign Key properties
             standard: All other properties (that aren't pk or fk)
-            assigned: Properties that don't match the following categories (can include pk/fk)
-            unset: Properties that have not been explicitly set (see Pydantic.model_dump for more info)
-            defaults: Properties that are equivalent to their default value (see Pydantic.model_dump for more info)
-            none: Properties that do not have a value (see Pydantic.model_dump for more info)
+            assigned: Properties that have a non-default value
+            defaults: Properties that are equivalent to their default value
+            none: Properties that do not have a value
         Property categories may be set to True (to include) or False (to exclude).
         If no arguments are provided, no properties will be returned.
         The categories are added/removed in the order that they are encountered as arguments.
@@ -151,7 +150,7 @@ class DAOModel(SQLModel):
             elif key is 'fk':
                 props = names_of(self.get_fk_properties())
             elif key is 'assigned':
-                props = self.model_dump(exclude_unset=True, exclude_defaults=True, exclude_none=True)
+                props = self.model_dump(exclude_defaults=True, exclude_none=True)
             else:
                 if key is 'standard':
                     exclude = self.get_pk_names() + names_of(self.get_fk_properties())

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -162,6 +162,10 @@ class DAOModel(SQLModel):
             result = result.union(props) if value else result.difference(props)
         return in_order(result, property_order)
 
+    def get_value_of(self, column: Column):
+        """Shortcut function to return the value for the specified Column"""
+        return getattr(self, column.name)
+
     def compare(self, other, include_pk: Optional[bool] = False) -> dict[str, tuple[Any, Any]]:
         """Compares this model to another, producing a diff.
 

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -249,7 +249,7 @@ class DAOModel(SQLModel):
         return dict(zip(cls.get_pk_names(), *pk_values))
 
     def copy_model(self, source: Self, *fields: str) -> None:
-        """Copies all values from another instance of this Model.
+        """Copies values from another instance of this Model.
 
         Unless the fields are specified, all but PK are copied.
 
@@ -260,17 +260,17 @@ class DAOModel(SQLModel):
             values = source.model_dump(include=set(fields))
         else:
             values = source.model_dump(exclude=set(source.get_pk_names()))
-        self.copy_values(copy_pk=True, **values)
+        self.set_values(set_pk=True, **values)
 
-    def copy_values(self, copy_pk: Optional[bool] = False, **values) -> None:
+    def set_values(self, set_pk: Optional[bool] = False, **values) -> None:
         """Copies property values to this Model.
 
         By default, Primary Key values are ignored.
 
-        :param copy_pk: True if you also wish to copy Primary Key values
-        :param values: The dict including values to copy
+        :param set_pk: True if you also wish to set Primary Key values
+        :param values: The dict including values to set
         """
-        skip = [] if copy_pk else self.get_pk_names()
+        skip = [] if set_pk else self.get_pk_names()
         properties = names_of(self.get_properties())
         for k, v in values.items():
             if k in properties and k not in skip:

--- a/daomodel/base_service.py
+++ b/daomodel/base_service.py
@@ -1,0 +1,41 @@
+from daomodel import DAOModel, all_models
+from daomodel.db import DAOFactory
+from daomodel.model_diff import ChangeSet, Preference
+
+
+SOURCE_VALUE = Preference.RIGHT
+DESTINATION_VALUE = Preference.LEFT
+
+
+class BaseService:
+    """A base for service layers specifically designed around DAOModels."""
+    def __init__(self, daos: DAOFactory):
+        self.daos = daos
+
+    def merge(self, source: DAOModel, *destination_pk_values, **conflict_resolution) -> None:
+        """Merges the given source model into the specified destination.
+
+        In some cases, specify conflict_resolution to successfully merge values.
+
+        :param source: The source DAOModel to be merged into the destination
+        :param destination_pk_values: The primary key values indicating where to merge the model
+        :raises: NotFound: if the destination model does not exist in the database
+        :raises: Conflict: if the source model fails to merge into the destination
+        """
+        model_dao = self.daos[type(source)]
+        destination = model_dao.get(*destination_pk_values)
+        if type(destination) is not type(source):
+            raise TypeError(f'{destination} is not of type {type(source)}')
+
+        ChangeSet(destination, source, **conflict_resolution).resolve_preferences().apply()
+        self._redirect_fks(source, destination)
+        model_dao.update(destination)
+        model_dao.remove(source)
+
+    def _redirect_fks(self, source: DAOModel, destination: DAOModel) -> None:
+        for model in all_models(self.daos.db.get_bind()):
+            model_dao = self.daos[model]
+            for column in model.get_references_of(source):
+                old_value = source.get_value_of(column)
+                new_value = destination.get_value_of(column)
+                model_dao.query.where(column == old_value).update({column: new_value})

--- a/daomodel/dao.py
+++ b/daomodel/dao.py
@@ -92,7 +92,7 @@ class DAO:
         :raises: Conflict if an entry already exists for the primary key
         """
         model = self.model_class(**filter_dict(*self.model_class.get_pk_names(), **values))
-        model.copy_values(**values)
+        model.set_values(**values)
         if commit:
             self.insert(model)
         return model
@@ -184,7 +184,7 @@ class DAO:
         model = self.query.get(pk)
         if model is None:
             raise NotFound(self.model_class(**values))
-        model.copy_values(**values)
+        model.set_values(**values)
         return model
 
     def find(self,

--- a/daomodel/dao.py
+++ b/daomodel/dao.py
@@ -19,8 +19,8 @@ class NotFound(Exception):
 
 class Conflict(Exception):
     """Indicates that the store could not be updated due to an existing conflict."""
-    def __init__(self, model: DAOModel):
-        self.detail = f"{model.__class__.doc_name()} {model} already exists"
+    def __init__(self, model: Optional[DAOModel] = None, msg: Optional[str] = None):
+        self.detail = msg if msg else f"{model.__class__.doc_name()} {model} already exists"
 
 
 T = TypeVar("T", bound=DAOModel)
@@ -148,7 +148,6 @@ class DAO:
             for k, v in zip(existing.get_pk_names(), new_pk_values):
                 setattr(existing, k, v)
             self.update(existing)
-
 
     def exists(self, model: T) -> bool:
         """

--- a/daomodel/dao.py
+++ b/daomodel/dao.py
@@ -92,7 +92,7 @@ class DAO:
         :raises: Conflict if an entry already exists for the primary key
         """
         model = self.model_class(**filter_dict(*self.model_class.get_pk_names(), **values))
-        model.set_values(**values)
+        model.set_values(ignore_pk=True, **values)
         if commit:
             self.insert(model)
         return model
@@ -184,7 +184,7 @@ class DAO:
         model = self.query.get(pk)
         if model is None:
             raise NotFound(self.model_class(**values))
-        model.set_values(**values)
+        model.set_values(ignore_pk=True, **values)
         return model
 
     def find(self,

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -194,3 +194,35 @@ class ChangeSet(ModelDiff):
         """
         self.left.set_values(**{field: self.get_resolution(field) for field in self.keys()})
         return self.right
+
+
+class MergeSet(ChangeSet):
+    def __init__(self, baseline: DAOModel, *targets: DAOModel):
+        super().__init__(baseline, targets[0])
+        self.left = baseline
+        self.right = targets
+        for model in targets:
+            self.assigned_in_target += model.get_property_names(assigned=True)
+
+        for model in targets:
+            for k, v in baseline.compare(model).items():
+                self[k] = (v[0], [None] * len(targets))
+
+        for index, model in enumerate(targets):
+            for k, v in self.items():
+                v[1][index] = model.get_value_of(k)
+
+    def get_preferred(self, field: str) -> Preference:
+        pass
+
+    def get_resolution(self, field: str) -> Any:
+        pass
+
+    def resolve_conflict(self, field: str) -> Any:
+        pass
+
+    def resolve_preferences(self) -> Self:
+        pass
+
+    def apply(self) -> DAOModel:
+        pass

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -4,10 +4,9 @@ from typing import Any, Optional, Iterable, Literal
 from daomodel import DAOModel
 from daomodel.dao import Conflict
 
-#todo double check docs
 
 class ModelDiff(dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
-    """A dictionary wrapper to provided extended functionality for model comparisons."""
+    """A dictionary wrapper to provide extended functionality for model comparisons."""
     def __init__(self, left: DAOModel, right: DAOModel, include_pk: Optional[bool] = True):
         super().__init__()
         self.left = left
@@ -20,9 +19,10 @@ class ModelDiff(dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
         return self.keys()
 
     def get_left(self, field: str) -> Any:
-        """Returns the left value for the specified field.
+        """Fetches the value of the left model.
 
         :param field: The name of the field to fetch
+        :return: The left value for the specified field
         :raises: KeyError if the field is invalid or otherwise not included in this diff
         """
         if field not in self:
@@ -30,9 +30,10 @@ class ModelDiff(dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
         return self.get(field)[0]
 
     def get_right(self, field: str) -> Any:
-        """Returns the right value for the specified field.
+        """Fetches the value of the right model.
 
         :param field: The name of the field to fetch
+        :return: The right value for the specified field
         :raises: KeyError if the field is invalid or otherwise not included in this diff
         """
         if field not in self:
@@ -41,7 +42,7 @@ class ModelDiff(dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
 
     @abstractmethod
     def get_preferred(self, field: str) -> Literal['left', 'right', 'neither', 'both', 'n/a']:
-        """Defines which of the different values is preferred.
+        """Defines which of the varying values is preferred.
 
         'neither' and 'both' may be redundant depending on the application.
         They are differentiated in the case of specifying "these are both bad" and "these are both acceptable".
@@ -68,17 +69,30 @@ class ChangeSet(ModelDiff):
         self.assigned_in_target = self.target.get_property_names(assigned=True)
 
     def get_baseline(self, field: str) -> Any:
-        """Returns the baseline value for the specified field."""
+        """Fetches the value of the baseline model.
+
+        :param field: The name of the field to fetch
+        :return: The baseline value for the specified field
+        :raises: KeyError if the field is invalid or otherwise not included in this diff
+        """
         return self.get(field)[0]
 
     def get_target(self, field: str) -> Any:
-        """Returns the new value for the specified field if the change set were to be applied."""
+        """Fetches the value of the target model.
+
+        :param field: The name of the field to fetch
+        :return: The target value for the specified field
+        :raises: KeyError if the field is invalid or otherwise not included in this diff
+        """
         return self.get(field)[1]
 
     def get_resolution(self, field: str) -> Any:
         """Returns the resolved value for the specified field.
 
-        If resolve_preferences() was not called, this will return the target value.
+        This will be the new value for the specified field if the change set were to be applied.
+
+        :param field: The name of the field to fetch
+        :return: The resolved value, which is the target value unless resolve_preferences() was called
         """
         return self.get(field)[1]
 
@@ -97,6 +111,7 @@ class ChangeSet(ModelDiff):
         A conflict occurs when both the baseline and target have unique meaningful values for a field.
 
         :param field: The field having a conflict
+        :return: The result of the resolution which may be the baseline value, target value, or something new entirely
         :raises: Conflict if a resolution cannot be determined
         """
         raise Conflict(msg=f'Unable to determine preferred result for {field}: '

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -94,7 +94,7 @@ class ChangeSet(ModelDiff):
         :param field: The name of the field to fetch
         :return: The resolved value, which is the target value unless resolve_preferences() was called
         """
-        return self.get(field)[1]
+        return self.get(field)[-1]
 
     def get_preferred(self, field: str) -> Literal['left', 'right', 'neither', 'both', 'n/a']:
         return (

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -113,10 +113,8 @@ class ChangeSet(ModelDiff):
     """
     def __init__(self, baseline: DAOModel, target: DAOModel, include_pk: Optional[bool] = False):
         super().__init__(baseline, target, include_pk)
-        self.baseline = self.left
-        self.target = self.right
-        self.assigned_in_baseline = self.baseline.get_property_names(assigned=True)
-        self.assigned_in_target = self.target.get_property_names(assigned=True)
+        self.assigned_in_baseline = self.left.get_property_names(assigned=True)
+        self.assigned_in_target = self.right.get_property_names(assigned=True)
 
     def get_baseline(self, field: str) -> Any:
         """Fetches the value of the baseline model.
@@ -194,5 +192,5 @@ class ChangeSet(ModelDiff):
 
         You will typically want to call resolve_preferences prior to this.
         """
-        self.baseline.set_values(**{field: self.get_resolution(field) for field in self.keys()})
-        return self.baseline
+        self.left.set_values(**{field: self.get_resolution(field) for field in self.keys()})
+        return self.right

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -219,7 +219,7 @@ class ChangeSet(ModelDiff):
         You will typically want to call resolve_preferences prior to this.
         """
         self.left.set_values(**{field: self.get_resolution(field) for field in self.keys()})
-        return self.right
+        return self.left
 
 
 class MergeSet(ChangeSet):

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -18,23 +18,36 @@ class ModelDiff(dict[str, tuple[Any, Any]]):
         return self.keys()
 
     def get_left(self, field: str) -> Any:
-        """Returns the left value for the specified field."""
+        """Returns the left value for the specified field.
+
+        :param field: The name of the field to fetch
+        :raises: KeyError if the field is invalid or otherwise not included in this diff
+        """
+        if field not in self:
+            raise KeyError(f'{field} not found in diff.')
         return self.get(field)[0]
 
     def get_right(self, field: str) -> Any:
-        """Returns the right value for the specified field."""
+        """Returns the right value for the specified field.
+
+        :param field: The name of the field to fetch
+        :raises: KeyError if the field is invalid or otherwise not included in this diff
+        """
+        if field not in self:
+            raise KeyError(f'{field} not found in diff.')
         return self.get(field)[1]
 
     @abstractmethod
-    def get_preferred(self, field: str) -> Literal['left', 'right', 'neither', 'both']:
+    def get_preferred(self, field: str) -> Literal['left', 'right', 'neither', 'both', 'n/a']:
         """Defines which of the different values is preferred.
 
         'neither' and 'both' may be redundant depending on the application.
         They are differentiated in the case of specifying "these are both bad" and "these are both acceptable".
+        'n/a' is used when it does not make sense to have a preference i.e. the name field of two customers.
 
         :param field: The name of the field
-        :return: 'left', 'right', 'neither', or 'both'
-        :raises: ValueError if the field is invalid or otherwise not included in this diff
+        :return: 'left', 'right', 'neither', 'both', or 'n/a'
+        :raises: KeyError if the field is invalid or otherwise not included in this diff
         """
         raise NotImplementedError(f'Cannot determine which value is preferred for {field}: '
                                   f'{self.get_left(field)} -> {self.get_right(field)}')

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -134,6 +134,10 @@ class ChangeSet(ModelDiff):
         """
         return self.get_right(field)
 
+    def has_target_value(self, field: str) -> bool:
+        """Returns True if the target value for the specified field exists"""
+        return self.get_target(field) is not None
+
     def get_resolution(self, field: str) -> Any:
         """Returns the resolved value for the specified field.
 
@@ -147,7 +151,7 @@ class ChangeSet(ModelDiff):
 
     def get_preferred(self, field: str) -> Preference:
         return (
-            Preference.LEFT if self.get_target(field) is None else
+            Preference.LEFT if not self.has_target_value(field) else
             Preference.BOTH if field in self.assigned_in_baseline and field in self.assigned_in_target else
             Preference.LEFT if field in self.assigned_in_baseline else
             Preference.RIGHT if field in self.assigned_in_target else
@@ -211,6 +215,9 @@ class MergeSet(ChangeSet):
         for index, model in enumerate(targets):
             for k, v in self.items():
                 v[1][index] = model.get_value_of(k)
+
+    def has_target_value(self, field: str) -> bool:
+        return any(target is not None for target in self.get_target(field))
 
     def get_preferred(self, field: str) -> Preference:
         pass

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -138,6 +138,10 @@ class ChangeSet(ModelDiff):
         """Returns True if the target value for the specified field exists"""
         return self.get_target(field) is not None
 
+    def all_values(self, field: str) -> list[Any]:
+        """Returns a list containing the baseline value followed by the target value for the specified field."""
+        return [self.get_left(field), self.get_right(field)]
+
     def get_resolution(self, field: str) -> Any:
         """Returns the resolved value for the specified field.
 
@@ -219,17 +223,6 @@ class MergeSet(ChangeSet):
     def has_target_value(self, field: str) -> bool:
         return any(target is not None for target in self.get_target(field))
 
-    def get_preferred(self, field: str) -> Preference:
-        pass
-
-    def get_resolution(self, field: str) -> Any:
-        pass
-
-    def resolve_conflict(self, field: str) -> Any:
-        pass
-
-    def resolve_preferences(self) -> Self:
-        pass
-
-    def apply(self) -> DAOModel:
-        pass
+    def all_values(self, field: str) -> list[Any]:
+        """Returns a list containing the baseline value followed by all target values for the specified field."""
+        return [self.get_baseline(field)] + self.get_target(field)

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -1,0 +1,40 @@
+from abc import abstractmethod
+from typing import Any, Optional, Iterable, Literal
+
+from daomodel import DAOModel
+
+
+class ModelDiff(dict[str, tuple[Any, Any]]):
+    """A dictionary wrapper to provided extended functionality for model comparisons."""
+    def __init__(self, left: DAOModel, right: DAOModel, include_pk: Optional[bool] = True):
+        super().__init__()
+        self.left = left
+        self.right = right
+        self.update(left.compare(right, include_pk=include_pk))
+
+    @property
+    def fields(self) -> Iterable[str]:
+        """The fields that have different values between the two models."""
+        return self.keys()
+
+    def get_left(self, field: str) -> Any:
+        """Returns the left value for the specified field."""
+        return self.get(field)[0]
+
+    def get_right(self, field: str) -> Any:
+        """Returns the right value for the specified field."""
+        return self.get(field)[1]
+
+    @abstractmethod
+    def get_preferred(self, field: str) -> Literal['left', 'right', 'neither', 'both']:
+        """Defines which of the different values is preferred.
+
+        'neither' and 'both' may be redundant depending on the application.
+        They are differentiated in the case of specifying "these are both bad" and "these are both acceptable".
+
+        :param field: The name of the field
+        :return: 'left', 'right', 'neither', or 'both'
+        :raises: ValueError if the field is invalid or otherwise not included in this diff
+        """
+        raise NotImplementedError(f'Cannot determine which value is preferred for {field}: '
+                                  f'{self.get_left(field)} -> {self.get_right(field)}')

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional, Iterable, Literal
+from typing import Any, Optional, Iterable, Literal, Self
 
 from daomodel import DAOModel
 from daomodel.dao import Conflict
@@ -117,9 +117,10 @@ class ChangeSet(ModelDiff):
         raise Conflict(msg=f'Unable to determine preferred result for {field}: '
                            f'{self.get_baseline(field)} -> {self.get_target(field)}')
 
-    def resolve_preferences(self) -> None:
+    def resolve_preferences(self) -> Self:
         """Removes unwanted changes, preserving the meaningful values, regardless of them being from baseline or target
 
+        :return: This ChangeSet to allow for chaining function calls
         :raises: Conflict if both baseline and target have meaningful values (unless resolve_conflict is overridden)
         """
         for field in list(self.fields):
@@ -136,6 +137,7 @@ class ChangeSet(ModelDiff):
                         self[field] = (self.get_baseline(field), self.get_target(field), resolution)
                 case 'right':
                     pass
+        return self
 
     def apply(self) -> DAOModel:
         """Enacts these changes upon the baseline.

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -136,3 +136,11 @@ class ChangeSet(ModelDiff):
                         self[field] = (self.get_baseline(field), self.get_target(field), resolution)
                 case 'right':
                     pass
+
+    def apply(self) -> DAOModel:
+        """Enacts these changes upon the baseline.
+
+        You will typically want to call resolve_preferences prior to this.
+        """
+        self.baseline.set_values(**{field: self.get_resolution(field) for field in self.fields})
+        return self.baseline

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -13,11 +13,6 @@ class ModelDiff(dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
         self.right = right
         self.update(left.compare(right, include_pk=include_pk))
 
-    @property
-    def fields(self) -> Iterable[str]:
-        """The fields that have different values between the two models."""
-        return self.keys()
-
     def get_left(self, field: str) -> Any:
         """Fetches the value of the left model.
 

--- a/daomodel/util.py
+++ b/daomodel/util.py
@@ -31,6 +31,20 @@ def names_of(properties: Iterable[Column]) -> list[str]:
     return [p.name for p in properties]
 
 
+def mode(values: Iterable[Any]) -> Any:
+    """
+    Determines the most frequently occurring value within the provided iterable.
+
+    In the case of a tie (multiple values with the same highest frequency),
+    the function returns the first value encountered with that frequency.
+
+    :param values: An iterable containing values to evaluate
+    :return: The most common value from the provided iterable
+    """
+    values = list(values)
+    return max(values, key=values.count)
+
+
 def values_from_dict(*keys, **values) -> tuple[Any, ...]:
     """
     Pulls specific values from a dictionary.

--- a/daomodel/util.py
+++ b/daomodel/util.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Iterable, Any, OrderedDict
 
 from sqlalchemy import Column, ColumnElement
@@ -47,6 +48,30 @@ def values_from_dict(*keys, **values) -> tuple[Any, ...]:
     return tuple(result)
 
 
+def retain_in_dict(d: dict[Any, Any], *keys: Any) -> dict[Any, Any]:
+    """Filters a dictionary to specified keys.
+
+    The source dict remains unmodified.
+
+    :param d: The dictionary to filter down
+    :param keys: The target keys for the new dict
+    :return: The reduced values as a new dict
+    """
+    return {key: d[key] for key in keys if key in d}
+
+
+def remove_from_dict(d: dict[Any, Any], *keys: Any) -> dict[Any, Any]:
+    """Removes specified key/value pairs from a dictionary.
+
+    The source dict remains unmodified.
+
+    :param d: The dictionary to adjust
+    :param keys: The keys to remove from the dict
+    :return: The modified values as a new dict
+    """
+    return {k: v for k, v in d.items() if k not in keys}
+
+
 def filter_dict(*keys, **values) -> dict[str, Any]:
     """
     Filters a dictionary to specified keys.
@@ -55,6 +80,7 @@ def filter_dict(*keys, **values) -> dict[str, Any]:
     :param values: The dictionary to filter down
     :return: The filter down values as a new dict
     """
+    warnings.warn('Use retain_in_dict instead', DeprecationWarning)
     return {key: values[key] for key in keys}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,11 @@ authors = [{name="Cody M Sommer", email="bassmastacod@gmail.com"}]
 description = "Provides an automatic DAO layer for your models"
 keywords = ["dao", "crud", "model", "database", "db", "search", "query", "sql", "sqlmodel", "sqlalchemy", "pydantic"]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = ["sqlalchemy", "sqlmodel", "str_case_util"]
 license = {text = "MIT"}
 classifiers = [
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from typing import Optional
 
 import pytest
@@ -60,7 +60,7 @@ class BasePerson(DAOModel):
 
 
 class Staff(BasePerson, table=True):
-    hire_date: datetime
+    hire_date: date
 
 
 class Student(BasePerson, table=True):

--- a/tests/test_all_models.py
+++ b/tests/test_all_models.py
@@ -9,4 +9,7 @@ from tests.conftest import Person, Book, Hall, Locker, Staff, Student
 def test_all_models():
     engine = create_engine()
     init_db(engine)
-    assert all_models(engine) == {Person, Book, Hall, Locker, Staff, Student}
+    expected = {Person, Book, Hall, Locker, Staff, Student}
+    assert all_models(engine) == expected
+    connection = engine.connect()
+    assert all_models(connection) == expected

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -1,0 +1,31 @@
+from datetime import date
+from typing import Iterable
+
+from daomodel.base_service import BaseService, SOURCE_VALUE, DESTINATION_VALUE
+from tests.conftest import Staff, TestDAOFactory
+
+
+def longest(values: Iterable[str]) -> str:
+    return max(values, key=len)
+
+
+def setup_staff(daos: TestDAOFactory) -> tuple[Staff, Staff]:
+    dao = daos[Staff]
+    ed = dao.create_with(id=1, name='Ed', hire_date=date(2023, 6, 15))
+    edward = dao.create_with(id=2, name='Edward', hire_date=date(2024, 8, 20))
+    return ed, edward
+
+
+def test_merge(daos: TestDAOFactory):
+    ed, edward = setup_staff(daos)
+    BaseService(daos).merge(ed, 2, name=longest, hire_date=min)
+    daos.assert_in_db(Staff, 2, name='Edward', hire_date=date(2023, 6, 15))
+    daos.assert_not_in_db(Staff, 1)
+
+
+def test_merge__source_destination_values(daos: TestDAOFactory):
+    ed, edward = setup_staff(daos)
+    BaseService(daos).merge(edward, 1, name=DESTINATION_VALUE, hire_date=SOURCE_VALUE)
+    daos.assert_in_db(Staff, 1, name='Ed', hire_date=date(2024, 8, 20))
+    daos.assert_not_in_db(Staff, 2)
+    

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -1,0 +1,182 @@
+from datetime import date
+from typing import Optional, Any
+
+import pytest
+
+from daomodel import DAOModel, PrimaryKey
+from daomodel.dao import Conflict
+from daomodel.model_diff import ChangeSet
+from tests.labeled_tests import labeled_tests
+
+
+class CalendarEvent(DAOModel, table=True):
+    title: str = PrimaryKey
+    day: date
+    time: Optional[str] = 'All Day'
+    location: Optional[str]
+    description: Optional[str]
+
+
+dads_entry = CalendarEvent(
+    title='Family Picnic',
+    day=date(2025, 6, 20),
+    time='11:00 AM',
+    location='Central Park',
+    description='Annual family picnic with games and BBQ.'
+)
+moms_entry = CalendarEvent(
+    title='Family Picnic',
+    day=date(2025, 6, 20),
+    time='12:00 PM',
+    location='Central Park',
+    description='Picnic with family and friends, do not forget the salads!'
+)
+sons_entry = CalendarEvent(
+    title='Family Picnic',
+    day=date(2025, 6, 19),
+    time='12:00 PM',
+    description='Bring your football and frisbee!'
+)
+daughters_entry = CalendarEvent(
+    title='Family Picnic',
+    day=date(2025, 6, 20),
+    time='All Day',
+    location='Central Park'
+)
+unrelated_entry = CalendarEvent(
+    title='Dentist Appointment',
+    day=date(2025, 7, 1)
+)
+
+
+class EventChangeSet(ChangeSet):
+    def resolve_conflict(self, field: str) -> Any:
+        match field:
+            case 'title':
+                raise Conflict(msg='Unexpected conflict for title field')
+            case 'day':
+                return max(self.get_baseline(field), self.get_target(field))
+            case 'time':
+                return min(self.get_baseline(field), self.get_target(field))
+            case 'location':
+                return self.get_target(field)
+            case 'description':
+                return '\n\n'.join([self.get_target(field), self.get_baseline(field)])
+            case _:
+                raise NotImplementedError(f'The field {field} is not supported')
+
+
+def test_change_set():
+    assert 'title' not in ChangeSet(dads_entry, unrelated_entry)
+
+
+def test_change_set__include_pk():
+    assert 'title' in ChangeSet(dads_entry, unrelated_entry, include_pk=True)
+
+
+def test_get_baseline_get_target():
+    change_set = ChangeSet(dads_entry, moms_entry)
+    assert change_set.get_baseline('time') == change_set.get_left('time') == '11:00 AM'
+    assert change_set.get_target('time') == change_set.get_right('time') == '12:00 PM'
+
+
+def test_get_resolution():
+    assert ChangeSet(dads_entry, moms_entry).get_resolution('time') == '12:00 PM'
+    assert ChangeSet(moms_entry, dads_entry).get_resolution('time') == '11:00 AM'
+
+
+@labeled_tests({
+    'left': [
+        (dads_entry, sons_entry, 'location', 'left'),
+        (dads_entry, daughters_entry, 'time', 'left'),
+        (dads_entry, daughters_entry, 'description', 'left'),
+        (sons_entry, daughters_entry, 'time', 'left'),
+        (sons_entry, daughters_entry, 'description', 'left')
+    ],
+    'right': [
+        (sons_entry, moms_entry, 'location', 'right'),
+        (daughters_entry, moms_entry, 'time', 'right'),
+        (daughters_entry, moms_entry, 'description', 'right'),
+        (sons_entry, daughters_entry, 'location', 'right')
+    ],
+    'both': [
+        (dads_entry, moms_entry, 'time', 'both'),
+        (dads_entry, moms_entry, 'description', 'both'),
+        (moms_entry, sons_entry, 'day', 'both')
+    ]
+})
+def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: str, expected: str):
+    assert ChangeSet(baseline, target).get_preferred(field) == expected
+
+
+@labeled_tests({
+    'dad => mom':
+        (dads_entry, moms_entry, {
+            'description': ('Annual family picnic with games and BBQ.', 'Picnic with family and friends, do not forget the salads!',
+                            'Picnic with family and friends, do not forget the salads!\n\nAnnual family picnic with games and BBQ.')
+        }),
+    'dad => son':
+        (dads_entry, sons_entry, {
+            'description': ('Annual family picnic with games and BBQ.', 'Bring your football and frisbee!',
+                            'Bring your football and frisbee!\n\nAnnual family picnic with games and BBQ.')
+        }),
+    'dad => daughter':
+        (dads_entry, daughters_entry, {}),
+    'mom => dad':
+        (moms_entry, dads_entry, {
+            'time': ('12:00 PM', '11:00 AM'),
+            'description': ('Picnic with family and friends, do not forget the salads!', 'Annual family picnic with games and BBQ.',
+                            'Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!')
+        }),
+    'mom => son':
+        (moms_entry, sons_entry, {
+            'description': ('Picnic with family and friends, do not forget the salads!', 'Bring your football and frisbee!',
+                            'Bring your football and frisbee!\n\nPicnic with family and friends, do not forget the salads!')
+        }),
+    'mom => daughter':
+        (moms_entry, daughters_entry, {}),
+    'son => dad':
+        (sons_entry, dads_entry, {
+            'day': (date(2025, 6, 19), date(2025, 6, 20)),
+            'time': ('12:00 PM', '11:00 AM'),
+            'location': (None, 'Central Park'),
+            'description': ('Bring your football and frisbee!', 'Annual family picnic with games and BBQ.',
+                            'Annual family picnic with games and BBQ.\n\nBring your football and frisbee!')
+        }),
+    'son => mom':
+        (sons_entry, moms_entry, {
+            'day': (date(2025, 6, 19), date(2025, 6, 20)),
+            'location': (None, 'Central Park'),
+            'description': ('Bring your football and frisbee!', 'Picnic with family and friends, do not forget the salads!',
+                            'Picnic with family and friends, do not forget the salads!\n\nBring your football and frisbee!')
+        }),
+    'son => daughter':
+        (sons_entry, daughters_entry, {
+            'day': (date(2025, 6, 19), date(2025, 6, 20)),
+            'location': (None, 'Central Park')
+        }),
+    'daughter => dad':
+        (daughters_entry, dads_entry, {
+            'time': ('All Day', '11:00 AM'),
+            'description': (None, 'Annual family picnic with games and BBQ.')
+        }),
+    'daughter => mom':
+        (daughters_entry, moms_entry, {
+            'time': ('All Day', '12:00 PM'),
+            'description': (None, 'Picnic with family and friends, do not forget the salads!')
+        }),
+    'daughter => son':
+        (daughters_entry, sons_entry, {
+            'time': ('All Day', '12:00 PM'),
+            'description': (None, 'Bring your football and frisbee!')
+        }),
+})
+def test_resolve_preferences(baseline: CalendarEvent, target: CalendarEvent, expected: dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
+    change_set = EventChangeSet(baseline, target)
+    change_set.resolve_preferences()
+    assert change_set == expected
+
+
+def test_resolve_preferences__conflict():
+    with pytest.raises(Conflict):
+        assert ChangeSet(dads_entry, moms_entry).resolve_preferences()

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -57,6 +57,7 @@ conflict_resolution = {
     'location': Preference.LEFT,
     'description': '\n\n'.join
 }
+merge_conflict_resolution = {**conflict_resolution, 'location': mode, 'description': Preference.LEFT}
 
 
 def test_change_set():
@@ -443,6 +444,46 @@ def test_resolve_preferences__conflict():
 })
 def test_apply(baseline: CalendarEvent, target: CalendarEvent, expected: CalendarEvent):
     change_set = ChangeSet(baseline.model_copy(), target, **conflict_resolution)
+    change_set.resolve_preferences()
+    assert change_set.apply() == expected
+
+
+@labeled_tests({
+    'dad <= mom, son, daughter':
+        (dads_entry, [moms_entry, sons_entry, daughters_entry], CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.'
+        )),
+    'mom <= son, daughter, dad':
+        (moms_entry, [sons_entry, daughters_entry, dads_entry], CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Picnic with family and friends, do not forget the salads!'
+        )),
+    'son <= daughter, dad, mom':
+        (sons_entry, [daughters_entry, dads_entry, moms_entry], CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Bring your football and frisbee!'
+        )),
+    'daughter <= dad, mom, son':
+        (sons_entry, [daughters_entry, dads_entry, moms_entry], CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.'
+        )),
+})
+def test_apply__merge_set(baseline: CalendarEvent, target: list[CalendarEvent], expected: CalendarEvent):
+    change_set = MergeSet(baseline.model_copy(), *target, **merge_conflict_resolution)
     change_set.resolve_preferences()
     assert change_set.apply() == expected
 

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -321,6 +321,6 @@ def test_resolve_preferences__conflict():
         )),
 })
 def test_apply(baseline: CalendarEvent, target: CalendarEvent, expected: CalendarEvent):
-    change_set = EventChangeSet(baseline, target)
+    change_set = EventChangeSet(baseline.model_copy(), target)
     change_set.resolve_preferences()
     assert change_set.apply() == expected

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -180,3 +180,107 @@ def test_resolve_preferences(baseline: CalendarEvent, target: CalendarEvent, exp
 def test_resolve_preferences__conflict():
     with pytest.raises(Conflict):
         assert ChangeSet(dads_entry, moms_entry).resolve_preferences()
+
+
+@labeled_tests({
+    'dad => mom':
+        (dads_entry, moms_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!'
+        )),
+    'dad => son':
+        (dads_entry, sons_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Bring your football and frisbee!\n\nAnnual family picnic with games and BBQ.'
+        )),
+    'dad => daughter':
+        (dads_entry, daughters_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.'
+        )),
+    'mom => dad':
+        (moms_entry, dads_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!'
+        )),
+    'mom => son':
+        (moms_entry, sons_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Bring your football and frisbee!\n\nPicnic with family and friends, do not forget the salads!'
+        )),
+    'mom => daughter':
+        (moms_entry, daughters_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Picnic with family and friends, do not forget the salads!'
+        )),
+    'son => dad':
+        (sons_entry, dads_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.\n\nBring your football and frisbee!'
+        )),
+    'son => mom':
+        (sons_entry, moms_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Picnic with family and friends, do not forget the salads!\n\nBring your football and frisbee!'
+        )),
+    'son => daughter':
+        (sons_entry, daughters_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Bring your football and frisbee!'
+        )),
+    'daughter => dad':
+        (daughters_entry, dads_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='11:00 AM',
+            location='Central Park',
+            description='Annual family picnic with games and BBQ.'
+        )),
+    'daughter => mom':
+        (daughters_entry, moms_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Picnic with family and friends, do not forget the salads!'
+        )),
+    'daughter => son':
+        (daughters_entry, sons_entry, CalendarEvent(
+            title='Family Picnic',
+            day=date(2025, 6, 20),
+            time='12:00 PM',
+            location='Central Park',
+            description='Bring your football and frisbee!'
+        )),
+})
+def test_apply(baseline: CalendarEvent, target: CalendarEvent, expected: CalendarEvent):
+    change_set = EventChangeSet(baseline, target)
+    change_set.resolve_preferences()
+    assert change_set.apply() == expected

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -55,11 +55,11 @@ class EventChangeSet(ChangeSet):
             case 'title':
                 raise Conflict(msg='Unexpected conflict for title field')
             case 'day':
-                return max(self.get_baseline(field), self.get_target(field))
+                return Preference.LEFT if self.get_baseline(field) > self.get_target(field) else Preference.RIGHT
             case 'time':
-                return min(self.get_baseline(field), self.get_target(field))
+                return Preference.LEFT if self.get_baseline(field) < self.get_target(field) else Preference.RIGHT
             case 'location':
-                return self.get_target(field)
+                return Preference.LEFT
             case 'description':
                 return '\n\n'.join([self.get_baseline(field), self.get_target(field)])
             case _:

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -5,7 +5,7 @@ import pytest
 
 from daomodel import DAOModel, PrimaryKey
 from daomodel.dao import Conflict
-from daomodel.model_diff import ChangeSet, Preference
+from daomodel.model_diff import ChangeSet, Preference, Resolved
 from tests.labeled_tests import labeled_tests
 
 
@@ -124,26 +124,38 @@ def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: st
 @labeled_tests({
     'dad => mom':
         (dads_entry, moms_entry, {
-            'description': ('Annual family picnic with games and BBQ.', 'Picnic with family and friends, do not forget the salads!',
-                            'Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!')
+            'description': (
+                    'Annual family picnic with games and BBQ.',
+                    Resolved('Picnic with family and friends, do not forget the salads!',
+                             'Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!')
+            )
         }),
     'dad => son':
         (dads_entry, sons_entry, {
-            'description': ('Annual family picnic with games and BBQ.', 'Bring your football and frisbee!',
-                            'Annual family picnic with games and BBQ.\n\nBring your football and frisbee!')
+            'description': (
+                    'Annual family picnic with games and BBQ.',
+                    Resolved('Bring your football and frisbee!',
+                             'Annual family picnic with games and BBQ.\n\nBring your football and frisbee!')
+            )
         }),
     'dad => daughter':
         (dads_entry, daughters_entry, {}),
     'mom => dad':
         (moms_entry, dads_entry, {
             'time': ('12:00 PM', '11:00 AM'),
-            'description': ('Picnic with family and friends, do not forget the salads!', 'Annual family picnic with games and BBQ.',
-                            'Picnic with family and friends, do not forget the salads!\n\nAnnual family picnic with games and BBQ.')
+            'description': (
+                    'Picnic with family and friends, do not forget the salads!',
+                    Resolved('Annual family picnic with games and BBQ.',
+                             'Picnic with family and friends, do not forget the salads!\n\nAnnual family picnic with games and BBQ.')
+            )
         }),
     'mom => son':
         (moms_entry, sons_entry, {
-            'description': ('Picnic with family and friends, do not forget the salads!', 'Bring your football and frisbee!',
-                            'Picnic with family and friends, do not forget the salads!\n\nBring your football and frisbee!')
+            'description': (
+                    'Picnic with family and friends, do not forget the salads!',
+                    Resolved('Bring your football and frisbee!',
+                             'Picnic with family and friends, do not forget the salads!\n\nBring your football and frisbee!')
+            )
         }),
     'mom => daughter':
         (moms_entry, daughters_entry, {}),
@@ -152,15 +164,21 @@ def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: st
             'day': (date(2025, 6, 19), date(2025, 6, 20)),
             'time': ('12:00 PM', '11:00 AM'),
             'location': (None, 'Central Park'),
-            'description': ('Bring your football and frisbee!', 'Annual family picnic with games and BBQ.',
-                            'Bring your football and frisbee!\n\nAnnual family picnic with games and BBQ.')
+            'description': (
+                    'Bring your football and frisbee!',
+                    Resolved('Annual family picnic with games and BBQ.',
+                             'Bring your football and frisbee!\n\nAnnual family picnic with games and BBQ.')
+            )
         }),
     'son => mom':
         (sons_entry, moms_entry, {
             'day': (date(2025, 6, 19), date(2025, 6, 20)),
             'location': (None, 'Central Park'),
-            'description': ('Bring your football and frisbee!', 'Picnic with family and friends, do not forget the salads!',
-                            'Bring your football and frisbee!\n\nPicnic with family and friends, do not forget the salads!')
+            'description': (
+                    'Bring your football and frisbee!',
+                    Resolved('Picnic with family and friends, do not forget the salads!',
+                             'Bring your football and frisbee!\n\nPicnic with family and friends, do not forget the salads!')
+            )
         }),
     'son => daughter':
         (sons_entry, daughters_entry, {
@@ -183,7 +201,7 @@ def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: st
             'description': (None, 'Bring your football and frisbee!')
         }),
 })
-def test_resolve_preferences(baseline: CalendarEvent, target: CalendarEvent, expected: dict[str, tuple[Any, Any]|tuple[Any, Any, Any]]):
+def test_resolve_preferences(baseline: CalendarEvent, target: CalendarEvent, expected: dict[str, tuple[Any, Any|Resolved]]):
     change_set = EventChangeSet(baseline, target)
     change_set.resolve_preferences()
     assert change_set == expected

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -96,7 +96,7 @@ def test_get_resolution__unresolved():
     assert ChangeSet(moms_entry, dads_entry).get_resolution('time') == '11:00 AM'
 
 
-@labeled_tests({
+get_preferred_tests = {
     'left': [
         (dads_entry, sons_entry, 'location', Preference.LEFT),
         (dads_entry, sons_entry, 'location', Preference.LEFT),
@@ -116,7 +116,8 @@ def test_get_resolution__unresolved():
         (dads_entry, moms_entry, 'description', Preference.BOTH),
         (moms_entry, sons_entry, 'day', Preference.BOTH)
     ]
-})
+}
+@labeled_tests(get_preferred_tests)
 def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: str, expected: Preference):
     assert ChangeSet(baseline, target).get_preferred(field) == expected
 
@@ -481,3 +482,8 @@ def test_apply(baseline: CalendarEvent, target: CalendarEvent, expected: Calenda
 })
 def test_merge_set(baseline: CalendarEvent, others: list[CalendarEvent, ...], expected: dict[str, tuple[Any, list[Any, ...]]]):
     assert MergeSet(baseline, *others) == expected
+
+
+@labeled_tests(get_preferred_tests)
+def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: str, expected: Preference):
+    assert MergeSet(baseline, *[target] * 3).get_preferred(field) == expected

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -61,7 +61,7 @@ class EventChangeSet(ChangeSet):
             case 'location':
                 return self.get_target(field)
             case 'description':
-                return '\n\n'.join([self.get_target(field), self.get_baseline(field)])
+                return '\n\n'.join([self.get_baseline(field), self.get_target(field)])
             case _:
                 raise NotImplementedError(f'The field {field} is not supported')
 
@@ -81,6 +81,17 @@ def test_get_baseline_get_target():
 
 
 def test_get_resolution():
+    change_set = EventChangeSet(dads_entry, moms_entry)
+    change_set.resolve_preferences()
+    assert (change_set.get_resolution('description') ==
+            'Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!')
+    change_set = EventChangeSet(moms_entry, dads_entry)
+    change_set.resolve_preferences()
+    assert (change_set.get_resolution('description') ==
+            'Picnic with family and friends, do not forget the salads!\n\nAnnual family picnic with games and BBQ.')
+
+
+def test_get_resolution__unresolved():
     assert ChangeSet(dads_entry, moms_entry).get_resolution('time') == '12:00 PM'
     assert ChangeSet(moms_entry, dads_entry).get_resolution('time') == '11:00 AM'
 
@@ -113,12 +124,12 @@ def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: st
     'dad => mom':
         (dads_entry, moms_entry, {
             'description': ('Annual family picnic with games and BBQ.', 'Picnic with family and friends, do not forget the salads!',
-                            'Picnic with family and friends, do not forget the salads!\n\nAnnual family picnic with games and BBQ.')
+                            'Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!')
         }),
     'dad => son':
         (dads_entry, sons_entry, {
             'description': ('Annual family picnic with games and BBQ.', 'Bring your football and frisbee!',
-                            'Bring your football and frisbee!\n\nAnnual family picnic with games and BBQ.')
+                            'Annual family picnic with games and BBQ.\n\nBring your football and frisbee!')
         }),
     'dad => daughter':
         (dads_entry, daughters_entry, {}),
@@ -126,12 +137,12 @@ def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: st
         (moms_entry, dads_entry, {
             'time': ('12:00 PM', '11:00 AM'),
             'description': ('Picnic with family and friends, do not forget the salads!', 'Annual family picnic with games and BBQ.',
-                            'Annual family picnic with games and BBQ.\n\nPicnic with family and friends, do not forget the salads!')
+                            'Picnic with family and friends, do not forget the salads!\n\nAnnual family picnic with games and BBQ.')
         }),
     'mom => son':
         (moms_entry, sons_entry, {
             'description': ('Picnic with family and friends, do not forget the salads!', 'Bring your football and frisbee!',
-                            'Bring your football and frisbee!\n\nPicnic with family and friends, do not forget the salads!')
+                            'Picnic with family and friends, do not forget the salads!\n\nBring your football and frisbee!')
         }),
     'mom => daughter':
         (moms_entry, daughters_entry, {}),
@@ -141,14 +152,14 @@ def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: st
             'time': ('12:00 PM', '11:00 AM'),
             'location': (None, 'Central Park'),
             'description': ('Bring your football and frisbee!', 'Annual family picnic with games and BBQ.',
-                            'Annual family picnic with games and BBQ.\n\nBring your football and frisbee!')
+                            'Bring your football and frisbee!\n\nAnnual family picnic with games and BBQ.')
         }),
     'son => mom':
         (sons_entry, moms_entry, {
             'day': (date(2025, 6, 19), date(2025, 6, 20)),
             'location': (None, 'Central Park'),
             'description': ('Bring your football and frisbee!', 'Picnic with family and friends, do not forget the salads!',
-                            'Picnic with family and friends, do not forget the salads!\n\nBring your football and frisbee!')
+                            'Bring your football and frisbee!\n\nPicnic with family and friends, do not forget the salads!')
         }),
     'son => daughter':
         (sons_entry, daughters_entry, {

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -5,7 +5,7 @@ import pytest
 
 from daomodel import DAOModel, PrimaryKey
 from daomodel.dao import Conflict
-from daomodel.model_diff import ChangeSet
+from daomodel.model_diff import ChangeSet, Preference
 from tests.labeled_tests import labeled_tests
 
 
@@ -98,25 +98,26 @@ def test_get_resolution__unresolved():
 
 @labeled_tests({
     'left': [
-        (dads_entry, sons_entry, 'location', 'left'),
-        (dads_entry, daughters_entry, 'time', 'left'),
-        (dads_entry, daughters_entry, 'description', 'left'),
-        (sons_entry, daughters_entry, 'time', 'left'),
-        (sons_entry, daughters_entry, 'description', 'left')
+        (dads_entry, sons_entry, 'location', Preference.LEFT),
+        (dads_entry, sons_entry, 'location', Preference.LEFT),
+        (dads_entry, daughters_entry, 'time', Preference.LEFT),
+        (dads_entry, daughters_entry, 'description', Preference.LEFT),
+        (sons_entry, daughters_entry, 'time', Preference.LEFT),
+        (sons_entry, daughters_entry, 'description', Preference.LEFT)
     ],
     'right': [
-        (sons_entry, moms_entry, 'location', 'right'),
-        (daughters_entry, moms_entry, 'time', 'right'),
-        (daughters_entry, moms_entry, 'description', 'right'),
-        (sons_entry, daughters_entry, 'location', 'right')
+        (sons_entry, moms_entry, 'location', Preference.RIGHT),
+        (daughters_entry, moms_entry, 'time', Preference.RIGHT),
+        (daughters_entry, moms_entry, 'description', Preference.RIGHT),
+        (sons_entry, daughters_entry, 'location', Preference.RIGHT)
     ],
     'both': [
-        (dads_entry, moms_entry, 'time', 'both'),
-        (dads_entry, moms_entry, 'description', 'both'),
-        (moms_entry, sons_entry, 'day', 'both')
+        (dads_entry, moms_entry, 'time', Preference.BOTH),
+        (dads_entry, moms_entry, 'description', Preference.BOTH),
+        (moms_entry, sons_entry, 'day', Preference.BOTH)
     ]
 })
-def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: str, expected: str):
+def test_get_preferred(baseline: CalendarEvent, target: CalendarEvent, field: str, expected: Preference):
     assert ChangeSet(baseline, target).get_preferred(field) == expected
 
 

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -80,6 +80,70 @@ def test_get_baseline_get_target():
     assert change_set.get_target('time') == change_set.get_right('time') == '12:00 PM'
 
 
+@labeled_tests({
+    'ChangeSet has target value':
+        (ChangeSet(dads_entry, moms_entry), 'time', True),
+    'ChangeSet does not have target value':
+        (ChangeSet(dads_entry, sons_entry), 'location', False),
+    'Single Target MergeSet has target value':
+        (MergeSet(dads_entry, moms_entry), 'time', True),
+    'Single Target MergeSet does not have target value':
+        (MergeSet(dads_entry, sons_entry), 'location', False),
+    'Multiple Target MergeSet has all target value':
+        (MergeSet(dads_entry, moms_entry, sons_entry, daughters_entry), 'time', True),
+    'Multiple Target MergeSet has some target value':
+        (MergeSet(dads_entry, moms_entry, sons_entry, daughters_entry), 'description', True),
+    'Multiple Target MergeSet has no target value':
+        (MergeSet(dads_entry, sons_entry, unrelated_entry), 'location', False),
+})
+def test_has_target_value(change_set: ChangeSet, field: str, expected: bool):
+    assert change_set.has_target_value(field) is expected
+
+
+@labeled_tests({
+    'ChangeSet':
+        (ChangeSet(dads_entry, moms_entry), 'time', ['11:00 AM', '12:00 PM']),
+    'ChangeSet None Baseline':
+        (ChangeSet(daughters_entry, sons_entry), 'description', [None, 'Bring your football and frisbee!']),
+    'Single Target MergeSet':
+        (MergeSet(dads_entry, sons_entry), 'day', [date(2025, 6, 20), date(2025, 6, 19)]),
+    'Multiple Target MergeSet':
+        (MergeSet(dads_entry, moms_entry, daughters_entry), 'time', [
+            '11:00 AM',
+            '12:00 PM',
+            'All Day'
+        ]),
+    'Multiple Target MergeSet with some unchanged values':
+        (MergeSet(dads_entry, moms_entry, daughters_entry), 'location', [
+            'Central Park',
+            'Central Park',
+            'The Park'
+        ]),
+    'Multiple Target MergeSet with None value':
+        (MergeSet(dads_entry, moms_entry, sons_entry, daughters_entry), 'description', [
+            'Annual family picnic with games and BBQ.',
+            'Picnic with family and friends, do not forget the salads!',
+            'Bring your football and frisbee!',
+            None
+        ]),
+    'Multiple Target MergeSet with None Baseline':
+        (MergeSet(sons_entry, dads_entry, daughters_entry), 'location', [
+            None,
+            'Central Park',
+            'The Park'
+        ]),
+    'Multiple Target MergeSet with all target matching':
+        (MergeSet(sons_entry, dads_entry, moms_entry, daughters_entry), 'day', [
+            date(2025, 6, 19),
+            date(2025, 6, 20),
+            date(2025, 6, 20),
+            date(2025, 6, 20)
+        ]),
+})
+def test_all_values(change_set: ChangeSet, field: str, expected: list[Any]):
+    assert change_set.all_values(field) == expected
+
+
 def test_get_resolution():
     change_set = EventChangeSet(dads_entry, moms_entry)
     change_set.resolve_preferences()

--- a/tests/test_change_set.py
+++ b/tests/test_change_set.py
@@ -177,6 +177,10 @@ def test_resolve_preferences(baseline: CalendarEvent, target: CalendarEvent, exp
     assert change_set == expected
 
 
+def test_resolve_preferences__chained():
+    assert EventChangeSet(moms_entry, dads_entry).resolve_preferences().get_baseline('time') == '12:00 PM'
+
+
 def test_resolve_preferences__conflict():
     with pytest.raises(Conflict):
         assert ChangeSet(dads_entry, moms_entry).resolve_preferences()

--- a/tests/test_dao_find.py
+++ b/tests/test_dao_find.py
@@ -93,7 +93,6 @@ def test_find__is_set_foreign_property(student_dao: DAO):
     assert student_dao.find(is_set_=Book.name) == SearchResults(having_book)
 
 
-@pytest.mark.skip(reason='Not yet implemented')
 def test_find__is_set_unsearchable(student_dao: DAO):
     with pytest.raises(Unsearchable):
         student_dao.find(is_set_=Hall.floor)

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Union, Any
+from typing import Iterable, Union, Any, Optional
 
 import pytest
 from sqlalchemy import Column
@@ -30,7 +30,7 @@ class BaseModel(DAOModel):
 class ComplicatedModel(BaseModel, table=True):
     pkC: int = PrimaryKey
     pkD: int = PrimaryKey
-    prop2: str
+    prop2: Optional[str]
     fkA: int = ForeignKey('simple_model.pkA')
     fkB: int = ForeignKey('foreign_key_model.pkB')
 
@@ -287,6 +287,28 @@ def test_get_value_of(model: DAOModel, column: Column, expected: Any):
                 complicated_instance,
                 ComplicatedModel(pkC=17, pkD=76, prop1='prop', prop2='erty', fkA=0, fkB=0),
                 {'fkA': (23, 0), 'fkB': (32, 0)}
+        )
+    ],
+    'none values': [
+        (
+                complicated_instance,
+                ComplicatedModel(pkC=17, pkD=76, prop1='new', prop2=None, fkA=23, fkB=32),
+                {'prop1': ('prop', 'new'), 'prop2': ('erty', None)}
+        ), (
+                ComplicatedModel(pkC=17, pkD=76, prop1='new', prop2=None, fkA=23, fkB=32),
+                complicated_instance,
+                {'prop1': ('new', 'prop'), 'prop2': (None, 'erty')}
+        )
+    ],
+    'unset values': [
+        (
+                complicated_instance,
+                ComplicatedModel(pkC=17, pkD=76, prop1='new', fkA=23, fkB=32),
+                {'prop1': ('prop', 'new'), 'prop2': ('erty', None)}
+        ), (
+                ComplicatedModel(pkC=17, pkD=76, prop1='new', fkA=23, fkB=32),
+                complicated_instance,
+                {'prop1': ('new', 'prop'), 'prop2': (None, 'erty')}
         )
     ]
 })

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -480,9 +480,9 @@ def test_copy_model__pk():
     assert other.fkB == 2
 
 
-def test_copy_values():
+def test_set_values():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.copy_values(prop1='new', fkB=3)
+    other.set_values(prop1='new', fkB=3)
     assert other.model_dump() == {
         'pkC': 12,
         'pkD': 34,
@@ -493,9 +493,9 @@ def test_copy_values():
     }
 
 
-def test_copy_values__extra_values():
+def test_set_values__extra_values():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.copy_values(prop1='new', other='extra')
+    other.set_values(prop1='new', other='extra')
     assert other.model_dump() == {
         'pkC': 12,
         'pkD': 34,
@@ -506,9 +506,9 @@ def test_copy_values__extra_values():
     }
 
 
-def test_copy_values__ignore_pk():
+def test_set_values__ignore_pk():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.copy_values(pkC=0, prop1='new')
+    other.set_values(pkC=0, prop1='new')
     assert other.model_dump() == {
         'pkC': 12,
         'pkD': 34,
@@ -519,9 +519,9 @@ def test_copy_values__ignore_pk():
     }
 
 
-def test_copy_values__pk():
+def test_set_values__pk():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.copy_values(copy_pk=True, pkC=0)
+    other.set_values(set_pk=True, pkC=0)
     assert other.model_dump() == {
         'pkC': 0,
         'pkD': 34,

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -235,6 +235,25 @@ def test_get_properties(model: type[DAOModel], expected: list[str]):
 
 
 @labeled_tests({
+    'primary key': [
+        (simple_instance, SimpleModel.pkA, 23),
+        (complicated_instance, ComplicatedModel.pkC, 17),
+        (complicated_instance, ComplicatedModel.pkD, 76)
+    ],
+    'foreign key': [
+        (complicated_instance, ComplicatedModel.fkA, 23),
+        (complicated_instance, ComplicatedModel.fkB, 32)
+    ],
+    'inherited column':
+        (complicated_instance, ComplicatedModel.prop1, 'prop'),
+    'standard column':
+        (complicated_instance, ComplicatedModel.prop2, 'erty'),
+})
+def test_get_value_of(model: DAOModel, column: Column, expected: Any):
+    assert model.get_value_of(column) == expected
+
+
+@labeled_tests({
     'no diff': [
         (complicated_instance, complicated_instance, {}),
         (complicated_instance, ComplicatedModel(pkC=17, pkD=76, prop1='prop', prop2='erty', fkA=23, fkB=32), {}),

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -428,7 +428,7 @@ def test_find_searchable_column(prop: Union[str, Column], expected: list[str]):
 
 def test_find_searchable_column__foreign_without_table():
     with pytest.raises(Unsearchable):
-        assert ComplicatedModel.find_searchable_column('prop', [])
+        ComplicatedModel.find_searchable_column('prop', [])
 
 
 @labeled_tests({

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -114,7 +114,7 @@ def test_tablename():
     ]
 })
 def test_has_column(model: DAOModel, column: Column, expected: bool):
-    assert model.has_column(column) == expected
+    assert model.has_column(column) is expected
 
 
 @labeled_tests({

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -313,13 +313,74 @@ def test_copy_model():
     assert complicated_instance.fkB == 32
 
 
+def test_copy_model__specific_fields():
+    other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
+    other.copy_model(complicated_instance, 'prop1', 'fkA')
+    assert other.pkC == 12
+    assert other.pkD == 34
+    assert other.prop1 == 'prop'
+    assert other.prop2 == 'values'
+    assert other.fkA == 23
+    assert other.fkB == 2
+
+
+def test_copy_model__pk():
+    other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
+    other.copy_model(complicated_instance, 'pkD')
+    assert other.pkC == 12
+    assert other.pkD == 76
+    assert other.prop1 == 'different'
+    assert other.prop2 == 'values'
+    assert other.fkA == 1
+    assert other.fkB == 2
+
+
 def test_copy_values():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.copy_values(pkC=0, prop1='new', other='extra')
+    other.copy_values(prop1='new', fkB=3)
     assert other.model_dump() == {
         'pkC': 12,
         'pkD': 34,
         'prop1': 'new',
+        'prop2': 'values',
+        'fkA': 1,
+        'fkB': 3
+    }
+
+
+def test_copy_values__extra_values():
+    other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
+    other.copy_values(prop1='new', other='extra')
+    assert other.model_dump() == {
+        'pkC': 12,
+        'pkD': 34,
+        'prop1': 'new',
+        'prop2': 'values',
+        'fkA': 1,
+        'fkB': 2
+    }
+
+
+def test_copy_values__ignore_pk():
+    other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
+    other.copy_values(pkC=0, prop1='new')
+    assert other.model_dump() == {
+        'pkC': 12,
+        'pkD': 34,
+        'prop1': 'new',
+        'prop2': 'values',
+        'fkA': 1,
+        'fkB': 2
+    }
+
+
+def test_copy_values__pk():
+    other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
+    other.copy_values(copy_pk=True, pkC=0)
+    assert other.model_dump() == {
+        'pkC': 0,
+        'pkD': 34,
+        'prop1': 'different',
         'prop2': 'values',
         'fkA': 1,
         'fkB': 2

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -248,9 +248,39 @@ def test_get_properties(model: type[DAOModel], expected: list[str]):
         (complicated_instance, ComplicatedModel.prop1, 'prop'),
     'standard column':
         (complicated_instance, ComplicatedModel.prop2, 'erty'),
+    'by str':
+        (complicated_instance, 'prop2', 'erty')
 })
 def test_get_value_of(model: DAOModel, column: Column, expected: Any):
     assert model.get_value_of(column) == expected
+
+
+@labeled_tests({
+    'no columns': [
+        (simple_instance, [], {}),
+        (complicated_instance, [], {})
+    ],
+    'single column': [
+        (simple_instance, ['pkA'], {'pkA': 23}),
+        (complicated_instance, ['pkC'], {'pkC': 17}),
+        (complicated_instance, ['pkD'], {'pkD': 76}),
+        (complicated_instance, ['prop1'], {'prop1': 'prop'}),
+        (complicated_instance, ['prop2'], {'prop2': 'erty'}),
+        (complicated_instance, ['fkA'], {'fkA': 23}),
+        (complicated_instance, ['fkB'], {'fkB': 32}),
+    ],
+    'multiple columns':
+        (complicated_instance, ['pkC', 'pkD', 'prop1', 'prop2', 'fkA', 'fkB'], {
+            'pkC': 17,
+            'pkD': 76,
+            'prop1': 'prop',
+            'prop2': 'erty',
+            'fkA': 23,
+            'fkB': 32
+        })
+})
+def test_get_values_of(model: DAOModel, columns: list[Column], expected: Any):
+    assert model.get_values_of(columns) == expected
 
 
 @labeled_tests({

--- a/tests/test_daomodel.py
+++ b/tests/test_daomodel.py
@@ -508,7 +508,7 @@ def test_set_values__extra_values():
 
 def test_set_values__ignore_pk():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.set_values(pkC=0, prop1='new')
+    other.set_values(ignore_pk=True, pkC=0, prop1='new')
     assert other.model_dump() == {
         'pkC': 12,
         'pkD': 34,
@@ -521,7 +521,7 @@ def test_set_values__ignore_pk():
 
 def test_set_values__pk():
     other = ComplicatedModel(pkC=12, pkD=34, prop1='different', prop2='values', fkA=1, fkB=2)
-    other.set_values(set_pk=True, pkC=0)
+    other.set_values(pkC=0)
     assert other.model_dump() == {
         'pkC': 0,
         'pkD': 34,

--- a/tests/test_get_property_names.py
+++ b/tests/test_get_property_names.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Any
 
 from sqlmodel import Field
 
@@ -165,48 +165,184 @@ primary_key_and_unset_foreign_key_properties = [
 ]
 
 
+all_property_values = {
+    'set_pk': 1,
+    'unset_pk': None,
+    'default_pk': 0,
+    'set_default_pk': 0,
+    'default_none_pk': None,
+    'set_none_pk': None,
+    'set_default_none_pk': None,
+    'set_fk': 1,
+    'unset_fk': None,
+    'default_fk': 0,
+    'set_default_fk': 0,
+    'default_none_fk': None,
+    'set_none_fk': None,
+    'set_default_none_fk': None,
+    'set': 1,
+    'unset': None,
+    'default': 0,
+    'set_default': 0,
+    'default_none': None,
+    'set_none': None,
+    'set_default_none': None
+}
+pk_property_values = {
+    'set_pk': 1,
+    'unset_pk': None,
+    'default_pk': 0,
+    'set_default_pk': 0,
+    'default_none_pk': None,
+    'set_none_pk': None,
+    'set_default_none_pk': None
+}
+fk_property_values = {
+    'set_fk': 1,
+    'unset_fk': None,
+    'default_fk': 0,
+    'set_default_fk': 0,
+    'default_none_fk': None,
+    'set_none_fk': None,
+    'set_default_none_fk': None
+}
+standard_property_values = {
+    'set': 1,
+    'unset': None,
+    'default': 0,
+    'set_default': 0,
+    'default_none': None,
+    'set_none': None,
+    'set_default_none': None
+}
+assigned_property_values = {
+    'set_pk': 1,
+    'set_fk': 1,
+    'set': 1
+}
+unset_property_values = {
+    'unset_pk': None,
+    'default_pk': 0,
+    'default_none_pk': None,
+    'unset_fk': None,
+    'default_fk': 0,
+    'default_none_fk': None,
+    'unset': None,
+    'default': 0,
+    'default_none': None
+}
+default_value_property_values = {
+    'unset_pk': None,
+    'default_pk': 0,
+    'set_default_pk': 0,
+    'default_none_pk': None,
+    'set_default_none_pk': None,
+    'unset_fk': None,
+    'default_fk': 0,
+    'set_default_fk': 0,
+    'default_none_fk': None,
+    'set_default_none_fk': None,
+    'unset': None,
+    'default': 0,
+    'set_default': 0,
+    'default_none': None,
+    'set_default_none': None
+}
+none_value_property_values = {
+    'unset_pk': None,
+    'default_none_pk': None,
+    'set_none_pk': None,
+    'set_default_none_pk': None,
+    'unset_fk': None,
+    'default_none_fk': None,
+    'set_none_fk': None,
+    'set_default_none_fk': None,
+    'unset': None,
+    'default_none': None,
+    'set_none': None,
+    'set_default_none': None
+}
+set_none_value_property_values = {
+    'set_none_pk': None,
+    'set_default_none_pk': None,
+    'set_none_fk': None,
+    'set_default_none_fk': None,
+    'set_none': None,
+    'set_default_none': None
+}
+set_to_non_none_default_property_values = {
+    'set_default_pk': 0,
+    'set_default_fk': 0,
+    'set_default': 0
+}
+standard_non_none_property_values = {
+    'set': 1,
+    'default': 0,
+    'set_default': 0
+}
+primary_key_and_unset_foreign_key_property_values = {
+    'set_pk': 1,
+    'unset_pk': None,
+    'default_pk': 0,
+    'set_default_pk': 0,
+    'default_none_pk': None,
+    'set_none_pk': None,
+    'set_default_none_pk': None,
+    'unset_fk': None,
+    'default_fk': 0,
+    'default_none_fk': None
+}
+
+
 @labeled_tests({
     'no properties': [
-        ({}, []),
-        ({'all': False}, []),
-        ({'pk': False}, []),
-        ({'unset': False}, []),
-        ({'defaults': False}, []),
-        ({'none': False}, []),
-        ({'pk': False, 'unset': False, 'defaults': False, 'none': False}, [])
+        ({}, [], {}),
+        ({'all': False}, [], {}),
+        ({'pk': False}, [], {}),
+        ({'unset': False}, [], {}),
+        ({'defaults': False}, [], {}),
+        ({'none': False}, [], {}),
+        ({'pk': False, 'unset': False, 'defaults': False, 'none': False}, [], {})
     ],
     'all properties': [
-        ({'all': True}, all_properties),
-        ({'pk': True, 'fk': True, 'standard': True}, all_properties)
+        ({'all': True}, all_properties, all_property_values),
+        ({'pk': True, 'fk': True, 'standard': True}, all_properties, all_property_values)
     ],
     'primary key properties': [
-        ({'pk': True}, pk_properties),
-        ({'all': True, 'fk': False, 'standard': False}, pk_properties)
+        ({'pk': True}, pk_properties, pk_property_values),
+        ({'all': True, 'fk': False, 'standard': False}, pk_properties, pk_property_values)
     ],
     'foreign key properties': [
-        ({'fk': True}, fk_properties),
-        ({'all': True, 'pk': False, 'standard': False}, fk_properties)
+        ({'fk': True}, fk_properties, fk_property_values),
+        ({'all': True, 'pk': False, 'standard': False}, fk_properties, fk_property_values)
     ],
     'standard properties': [
-        ({'standard': True}, standard_properties),
-        ({'all': True, 'pk': False, 'fk': False}, standard_properties)
+        ({'standard': True}, standard_properties, standard_property_values),
+        ({'all': True, 'pk': False, 'fk': False}, standard_properties, standard_property_values)
     ],
     'assigned properties': [
-        ({'assigned': True}, assigned_properties),
-        ({'all': True, 'unset': False, 'defaults': False, 'none': False}, assigned_properties)
+        ({'assigned': True}, assigned_properties, assigned_property_values),
+        ({'all': True, 'unset': False, 'defaults': False, 'none': False}, assigned_properties, assigned_property_values)
     ],
-    'unset properties':
-        ({'unset': True}, unset_properties),
-    'default value properties':
-        ({'defaults': True}, default_value_properties),
-    'none value properties':
-        ({'none': True}, none_value_properties),
+    'unset properties': [
+        ({'unset': True}, unset_properties, unset_property_values)
+    ],
+    'default value properties': [
+        ({'defaults': True}, default_value_properties, default_value_property_values)
+    ],
+    'none value properties': [
+        ({'none': True}, none_value_properties, none_value_property_values)
+    ],
     'mixed property categories': [
-        ({'none': True, 'unset': False}, set_none_value_properties),
-        ({'defaults': True, 'unset': False, 'none': False}, set_to_non_none_default_properties),
-        ({'standard': True, 'none': False}, standard_non_none_properties),
-        ({'unset': True, 'standard': False, 'pk': True}, primary_key_and_unset_foreign_key_properties),
+        ({'none': True, 'unset': False}, set_none_value_properties, set_none_value_property_values),
+        ({'defaults': True, 'unset': False, 'none': False}, set_to_non_none_default_properties, set_to_non_none_default_property_values),
+        ({'standard': True, 'none': False}, standard_non_none_properties, standard_non_none_property_values),
+        ({'unset': True, 'standard': False, 'pk': True}, primary_key_and_unset_foreign_key_properties, primary_key_and_unset_foreign_key_property_values)
     ]
 })
-def test_get_property_names(property_modifications: dict[str, bool], expected: list[str]):
-    assert property_model.get_property_names(**property_modifications) == expected
+def test_get_property_names_get_property_values(
+        property_modifications: dict[str, bool],
+        expected_property_names: list[str],
+        expected_property_values: dict[str, Any]):
+    assert property_model.get_property_names(**property_modifications) == expected_property_names
+    assert property_model.get_property_values(**property_modifications) == expected_property_values

--- a/tests/test_get_property_names.py
+++ b/tests/test_get_property_names.py
@@ -86,6 +86,11 @@ standard_properties = [
     'set_none',
     'set_default_none'
 ]
+assigned_properties = [
+    'set_pk',
+    'set_fk',
+    'set',
+]
 unset_properties = [
     'unset_pk',
     'default_pk',
@@ -185,6 +190,10 @@ primary_key_and_unset_foreign_key_properties = [
     'standard properties': [
         ({'standard': True}, standard_properties),
         ({'all': True, 'pk': False, 'fk': False}, standard_properties)
+    ],
+    'assigned properties': [
+        ({'assigned': True}, assigned_properties),
+        ({'all': True, 'unset': False, 'defaults': False, 'none': False}, assigned_properties)
     ],
     'unset properties':
         ({'unset': True}, unset_properties),

--- a/tests/test_get_property_names.py
+++ b/tests/test_get_property_names.py
@@ -36,134 +36,6 @@ property_model = PropertyModel(set_pk=1, set_default_pk=0, set_none_pk=None, set
                        set_fk=1, set_default_fk=0, set_none_fk=None, set_default_none_fk=None,
                        set=1, set_default=0, set_none=None, set_default_none=None)
 
-all_properties = [
-    'set_pk',
-    'unset_pk',
-    'default_pk',
-    'set_default_pk',
-    'default_none_pk',
-    'set_none_pk',
-    'set_default_none_pk',
-    'set_fk',
-    'unset_fk',
-    'default_fk',
-    'set_default_fk',
-    'default_none_fk',
-    'set_none_fk',
-    'set_default_none_fk',
-    'set',
-    'unset',
-    'default',
-    'set_default',
-    'default_none',
-    'set_none',
-    'set_default_none'
-]
-pk_properties = [
-    'set_pk',
-    'unset_pk',
-    'default_pk',
-    'set_default_pk',
-    'default_none_pk',
-    'set_none_pk',
-    'set_default_none_pk'
-]
-fk_properties = [
-    'set_fk',
-    'unset_fk',
-    'default_fk',
-    'set_default_fk',
-    'default_none_fk',
-    'set_none_fk',
-    'set_default_none_fk'
-]
-standard_properties = [
-    'set',
-    'unset',
-    'default',
-    'set_default',
-    'default_none',
-    'set_none',
-    'set_default_none'
-]
-assigned_properties = [
-    'set_pk',
-    'set_fk',
-    'set',
-]
-unset_properties = [
-    'unset_pk',
-    'default_pk',
-    'default_none_pk',
-    'unset_fk',
-    'default_fk',
-    'default_none_fk',
-    'unset',
-    'default',
-    'default_none'
-]
-default_value_properties = [
-    'unset_pk',
-    'default_pk',
-    'set_default_pk',
-    'default_none_pk',
-    'set_default_none_pk',
-    'unset_fk',
-    'default_fk',
-    'set_default_fk',
-    'default_none_fk',
-    'set_default_none_fk',
-    'unset',
-    'default',
-    'set_default',
-    'default_none',
-    'set_default_none'
-]
-none_value_properties = [
-    'unset_pk',
-    'default_none_pk',
-    'set_none_pk',
-    'set_default_none_pk',
-    'unset_fk',
-    'default_none_fk',
-    'set_none_fk',
-    'set_default_none_fk',
-    'unset',
-    'default_none',
-    'set_none',
-    'set_default_none'
-]
-set_none_value_properties = [
-    'set_none_pk',
-    'set_default_none_pk',
-    'set_none_fk',
-    'set_default_none_fk',
-    'set_none',
-    'set_default_none'
-]
-set_to_non_none_default_properties = [
-    'set_default_pk',
-    'set_default_fk',
-    'set_default'
-]
-standard_non_none_properties = [
-    'set',
-    'default',
-    'set_default'
-]
-primary_key_and_unset_foreign_key_properties = [
-    'set_pk',
-    'unset_pk',
-    'default_pk',
-    'set_default_pk',
-    'default_none_pk',
-    'set_none_pk',
-    'set_default_none_pk',
-    'unset_fk',
-    'default_fk',
-    'default_none_fk'
-]
-
 
 all_property_values = {
     'set_pk': 1,
@@ -220,17 +92,6 @@ assigned_property_values = {
     'set_fk': 1,
     'set': 1
 }
-unset_property_values = {
-    'unset_pk': None,
-    'default_pk': 0,
-    'default_none_pk': None,
-    'unset_fk': None,
-    'default_fk': 0,
-    'default_none_fk': None,
-    'unset': None,
-    'default': 0,
-    'default_none': None
-}
 default_value_property_values = {
     'unset_pk': None,
     'default_pk': 0,
@@ -262,17 +123,12 @@ none_value_property_values = {
     'set_none': None,
     'set_default_none': None
 }
-set_none_value_property_values = {
-    'set_none_pk': None,
-    'set_default_none_pk': None,
-    'set_none_fk': None,
-    'set_default_none_fk': None,
-    'set_none': None,
-    'set_default_none': None
-}
-set_to_non_none_default_property_values = {
+non_none_default_property_values = {
+    'default_pk': 0,
     'set_default_pk': 0,
+    'default_fk': 0,
     'set_default_fk': 0,
+    'default': 0,
     'set_default': 0
 }
 standard_non_none_property_values = {
@@ -280,7 +136,10 @@ standard_non_none_property_values = {
     'default': 0,
     'set_default': 0
 }
-primary_key_and_unset_foreign_key_property_values = {
+assigned_foreign_key_property_values = {
+    'set_fk': 1,
+}
+primary_key_and_none_value_foreign_key_property_values = {
     'set_pk': 1,
     'unset_pk': None,
     'default_pk': 0,
@@ -289,60 +148,57 @@ primary_key_and_unset_foreign_key_property_values = {
     'set_none_pk': None,
     'set_default_none_pk': None,
     'unset_fk': None,
-    'default_fk': 0,
-    'default_none_fk': None
+    'default_none_fk': None,
+    'set_none_fk': None,
+    'set_default_none_fk': None
 }
 
 
 @labeled_tests({
     'no properties': [
-        ({}, [], {}),
-        ({'all': False}, [], {}),
-        ({'pk': False}, [], {}),
-        ({'unset': False}, [], {}),
-        ({'defaults': False}, [], {}),
-        ({'none': False}, [], {}),
-        ({'pk': False, 'unset': False, 'defaults': False, 'none': False}, [], {})
+        ({}, {}),
+        ({'all': False}, {}),
+        ({'pk': False}, {}),
+        ({'assigned': False}, {}),
+        ({'defaults': False}, {}),
+        ({'none': False}, {}),
+        ({'pk': False, 'assigned': False, 'defaults': False, 'none': False}, {})
     ],
     'all properties': [
-        ({'all': True}, all_properties, all_property_values),
-        ({'pk': True, 'fk': True, 'standard': True}, all_properties, all_property_values)
+        ({'all': True}, all_property_values),
+        ({'pk': True, 'fk': True, 'standard': True}, all_property_values)
     ],
     'primary key properties': [
-        ({'pk': True}, pk_properties, pk_property_values),
-        ({'all': True, 'fk': False, 'standard': False}, pk_properties, pk_property_values)
+        ({'pk': True}, pk_property_values),
+        ({'all': True, 'fk': False, 'standard': False}, pk_property_values)
     ],
     'foreign key properties': [
-        ({'fk': True}, fk_properties, fk_property_values),
-        ({'all': True, 'pk': False, 'standard': False}, fk_properties, fk_property_values)
+        ({'fk': True}, fk_property_values),
+        ({'all': True, 'pk': False, 'standard': False}, fk_property_values)
     ],
     'standard properties': [
-        ({'standard': True}, standard_properties, standard_property_values),
-        ({'all': True, 'pk': False, 'fk': False}, standard_properties, standard_property_values)
+        ({'standard': True}, standard_property_values),
+        ({'all': True, 'pk': False, 'fk': False}, standard_property_values)
     ],
     'assigned properties': [
-        ({'assigned': True}, assigned_properties, assigned_property_values),
-        ({'all': True, 'unset': False, 'defaults': False, 'none': False}, assigned_properties, assigned_property_values)
-    ],
-    'unset properties': [
-        ({'unset': True}, unset_properties, unset_property_values)
+        ({'assigned': True}, assigned_property_values),
+        ({'all': True, 'defaults': False, 'none': False}, assigned_property_values)
     ],
     'default value properties': [
-        ({'defaults': True}, default_value_properties, default_value_property_values)
+        ({'defaults': True}, default_value_property_values)
     ],
     'none value properties': [
-        ({'none': True}, none_value_properties, none_value_property_values)
+        ({'none': True}, none_value_property_values)
     ],
     'mixed property categories': [
-        ({'none': True, 'unset': False}, set_none_value_properties, set_none_value_property_values),
-        ({'defaults': True, 'unset': False, 'none': False}, set_to_non_none_default_properties, set_to_non_none_default_property_values),
-        ({'standard': True, 'none': False}, standard_non_none_properties, standard_non_none_property_values),
-        ({'unset': True, 'standard': False, 'pk': True}, primary_key_and_unset_foreign_key_properties, primary_key_and_unset_foreign_key_property_values)
+        ({'defaults': True, 'none': False}, non_none_default_property_values),
+        ({'standard': True, 'none': False}, standard_non_none_property_values),
+        ({'assigned': True, 'pk': False, 'standard': False}, assigned_foreign_key_property_values),
+        ({'none': True, 'standard': False, 'pk': True}, primary_key_and_none_value_foreign_key_property_values)
     ]
 })
 def test_get_property_names_get_property_values(
         property_modifications: dict[str, bool],
-        expected_property_names: list[str],
         expected_property_values: dict[str, Any]):
-    assert property_model.get_property_names(**property_modifications) == expected_property_names
+    assert property_model.get_property_names(**property_modifications) == list(expected_property_values.keys())
     assert property_model.get_property_values(**property_modifications) == expected_property_values

--- a/tests/test_model_diff.py
+++ b/tests/test_model_diff.py
@@ -373,7 +373,7 @@ def test_get_left_get_right__invalid():
         (multi_family, single_family, 'apt', Preference.NOT_APPLICABLE),
     ],
 })
-def test_get_preferred(left: Rental, right: Rental, field: str,expected: Preference):
+def test_get_preferred(left: Rental, right: Rental, field: str, expected: Preference):
     assert RentalDiff(left, right).get_preferred(field) == expected
 
 

--- a/tests/test_model_diff.py
+++ b/tests/test_model_diff.py
@@ -1,0 +1,266 @@
+from decimal import Decimal
+from enum import Enum, auto
+from typing import Optional, Any
+
+from daomodel import DAOModel, PrimaryKey, OptionalPrimaryKey
+from daomodel.model_diff import ModelDiff
+from tests.labeled_tests import labeled_tests
+
+
+class LaundryStatus(Enum):
+    Private = auto()
+    Shared = auto()
+    Public = auto()
+
+
+class Rental(DAOModel, table=True):
+    address: str = PrimaryKey
+    apt: Optional[str] = OptionalPrimaryKey
+    dwelling_type: str
+    sqft: int
+    bedrooms: int
+    bathrooms: Decimal
+    garage_parking: int = 0
+    laundry: Optional[LaundryStatus] = None
+    cost: int
+
+
+one_full = Decimal('1')
+one_full_one_half = Decimal('1.1')
+two_full = Decimal('2')
+two_full_two_half = Decimal('2.2')
+
+
+dorm = Rental(
+    address='123 College Ave',
+    apt='12',
+    dwelling_type='Dormitory',
+    sqft=200,
+    bedrooms=1,
+    bathrooms=one_full,
+    laundry=LaundryStatus.Public,
+    cost=0
+)
+apartment = Rental(
+    address='456 City Plaza',
+    apt='101',
+    dwelling_type='Apartment',
+    sqft=850,
+    bedrooms=2,
+    bathrooms=one_full,
+    garage_parking=1,
+    laundry=LaundryStatus.Shared,
+    cost=1200
+)
+apartment_two = Rental(
+    address='456 City Plaza',
+    apt='102',
+    dwelling_type='Apartment',
+    sqft=850,
+    bedrooms=2,
+    bathrooms=one_full,
+    garage_parking=1,
+    laundry=LaundryStatus.Shared,
+    cost=1200
+)
+multi_family = Rental(
+    address='789 Suburb St',
+    apt='B',
+    dwelling_type='Multi-family House',
+    sqft=950,
+    bedrooms=1,
+    bathrooms=one_full_one_half,
+    cost=1800
+)
+town_home = Rental(
+    address='321 Maple Dr',
+    dwelling_type='Town home',
+    sqft=1400,
+    bedrooms=3,
+    bathrooms=two_full,
+    garage_parking=1,
+    laundry=LaundryStatus.Private,
+    cost=2200
+)
+single_family = Rental(
+    address='987 Country Rd',
+    dwelling_type='House',
+    sqft=1800,
+    bedrooms=4,
+    bathrooms=two_full_two_half,
+    garage_parking=2,
+    laundry=LaundryStatus.Private,
+    cost=3000
+)
+
+
+@labeled_tests({
+    'dorm vs apartment':
+        (dorm, apartment, {
+            'dwelling_type': ('Dormitory', 'Apartment'),
+            'sqft': (200, 850),
+            'bedrooms': (1, 2),
+            'garage_parking': (0, 1),
+            'laundry': (LaundryStatus.Public, LaundryStatus.Shared),
+            'cost': (0, 1200)
+        }),
+    'dorm vs multi family':
+        (dorm, multi_family, {
+            'dwelling_type': ('Dormitory', 'Multi-family House'),
+            'sqft': (200, 950),
+            'bathrooms': (Decimal('1'), Decimal('1.1')),
+            'laundry': (LaundryStatus.Public, None),
+            'cost': (0, 1800)
+        }),
+    'dorm vs town home':
+        (dorm, town_home, {
+            'dwelling_type': ('Dormitory', 'Town home'),
+            'sqft': (200, 1400),
+            'bedrooms': (1, 3),
+            'bathrooms': (Decimal('1'), Decimal('2')),
+            'garage_parking': (0, 1),
+            'laundry': (LaundryStatus.Public, LaundryStatus.Private),
+            'cost': (0, 2200)
+        }),
+    'dorm vs single family':
+        (dorm, single_family, {
+            'dwelling_type': ('Dormitory', 'House'),
+            'sqft': (200, 1800),
+            'bedrooms': (1, 4),
+            'bathrooms': (Decimal('1'), Decimal('2.2')),
+            'garage_parking': (0, 2),
+            'laundry': (LaundryStatus.Public, LaundryStatus.Private),
+            'cost': (0, 3000)
+        }),
+    'apartment vs multi family':
+        (apartment, multi_family, {
+            'dwelling_type': ('Apartment', 'Multi-family House'),
+            'sqft': (850, 950),
+            'bedrooms': (2, 1),
+            'bathrooms': (Decimal('1'), Decimal('1.1')),
+            'garage_parking': (1, 0),
+            'laundry': (LaundryStatus.Shared, None),
+            'cost': (1200, 1800)
+        }),
+    'apartment vs town home':
+        (apartment, town_home, {
+            'dwelling_type': ('Apartment', 'Town home'),
+            'sqft': (850, 1400),
+            'bedrooms': (2, 3),
+            'bathrooms': (Decimal('1'), Decimal('2')),
+            'laundry': (LaundryStatus.Shared, LaundryStatus.Private),
+            'cost': (1200, 2200)
+        }),
+    'apartment vs single family':
+        (apartment, single_family, {
+            'dwelling_type': ('Apartment', 'House'),
+            'sqft': (850, 1800),
+            'bedrooms': (2, 4),
+            'bathrooms': (Decimal('1'), Decimal('2.2')),
+            'garage_parking': (1, 2),
+            'laundry': (LaundryStatus.Shared, LaundryStatus.Private),
+            'cost': (1200, 3000)
+        }),
+    'multi family vs town home':
+        (multi_family, town_home, {
+            'dwelling_type': ('Multi-family House', 'Town home'),
+            'sqft': (950, 1400),
+            'bedrooms': (1, 3),
+            'bathrooms': (Decimal('1.1'), Decimal('2')),
+            'garage_parking': (0, 1),
+            'laundry': (None, LaundryStatus.Private),
+            'cost': (1800, 2200)
+        }),
+    'multi family vs single family':
+        (multi_family, single_family, {
+            'dwelling_type': ('Multi-family House', 'House'),
+            'sqft': (950, 1800),
+            'bedrooms': (1, 4),
+            'bathrooms': (Decimal('1.1'), Decimal('2.2')),
+            'garage_parking': (0, 2),
+            'laundry': (None, LaundryStatus.Private),
+            'cost': (1800, 3000)
+        }),
+    'town home vs single family':
+        (town_home, single_family, {
+            'dwelling_type': ('Town home', 'House'),
+            'sqft': (1400, 1800),
+            'bedrooms': (3, 4),
+            'bathrooms': (Decimal('2'), Decimal('2.2')),
+            'garage_parking': (1, 2),
+            'cost': (2200, 3000)
+        }),
+    'empty diff':
+        (apartment, apartment_two, {})
+})
+def test_get_property_names(left: Rental, right: Rental, expected: dict[str, tuple[Any, Any]]):
+    assert ModelDiff(left, right, include_pk=False) == expected
+
+
+@labeled_tests({
+    'same address':
+        (apartment, apartment_two, {
+            'apt': ('101', '102')
+        }),
+    'right None':
+        (multi_family, town_home, {
+            'address': ('789 Suburb St', '321 Maple Dr'),
+            'apt': ('B', None)
+        }),
+    'left None':
+        (single_family, multi_family, {
+            'address': ('987 Country Rd', '789 Suburb St'),
+            'apt': (None, 'B')
+        }),
+    'both None':
+        (town_home, single_family, {
+            'address': ('321 Maple Dr', '987 Country Rd')
+        })
+})
+def test_get_property_names__pk(left: Rental, right: Rental, expected: dict[str, tuple[Any, Any]]):
+    diff = ModelDiff(left, right)
+    pk_diff = {key: diff[key] for key in ['address', 'apt'] if key in diff}
+    assert pk_diff == expected
+
+
+@labeled_tests({
+    'all fields':
+        (multi_family, single_family, {
+            'address',
+            'apt',
+            'dwelling_type',
+            'sqft',
+            'bedrooms',
+            'bathrooms',
+            'garage_parking',
+            'laundry',
+            'cost'
+        }),
+    'partial fields':
+        (dorm, multi_family, {
+            'address',
+            'apt',
+            'dwelling_type',
+            'sqft',
+            'bathrooms',
+            'laundry',
+            'cost'
+        }),
+    'single field':
+        (apartment, apartment_two, {'apt'}),
+    'no fields': [
+        (dorm, dorm, set()),
+        (apartment, apartment, set()),
+        (multi_family, multi_family, set()),
+        (town_home, town_home, set()),
+        (single_family, single_family, set())
+    ]
+})
+def test_fields(left: Rental, right: Rental, expected: set[str]):
+    assert ModelDiff(left, right).fields == expected
+
+
+def test_fields__exclude_pk():
+    assert ModelDiff(single_family, dorm, include_pk=False).fields == {
+        'dwelling_type', 'sqft', 'bedrooms', 'bathrooms', 'garage_parking', 'laundry', 'cost'
+    }

--- a/tests/test_model_diff.py
+++ b/tests/test_model_diff.py
@@ -260,49 +260,6 @@ def test_model_diff__pk(left: Rental, right: Rental, expected: dict[str, tuple[A
     assert pk_diff == expected
 
 
-@labeled_tests({
-    'all fields':
-        (multi_family, single_family, {
-            'address',
-            'apt',
-            'dwelling_type',
-            'sqft',
-            'bedrooms',
-            'bathrooms',
-            'garage_parking',
-            'laundry',
-            'cost'
-        }),
-    'partial fields':
-        (dorm, multi_family, {
-            'address',
-            'apt',
-            'dwelling_type',
-            'sqft',
-            'bathrooms',
-            'laundry',
-            'cost'
-        }),
-    'single field':
-        (apartment, apartment_two, {'apt'}),
-    'no fields': [
-        (dorm, dorm, set()),
-        (apartment, apartment, set()),
-        (multi_family, multi_family, set()),
-        (town_home, town_home, set()),
-        (single_family, single_family, set())
-    ]
-})
-def test_fields(left: Rental, right: Rental, expected: set[str]):
-    assert ModelDiff(left, right).fields == expected
-
-
-def test_fields__exclude_pk():
-    assert ModelDiff(single_family, dorm, include_pk=False).fields == {
-        'dwelling_type', 'sqft', 'bedrooms', 'bathrooms', 'garage_parking', 'laundry', 'cost'
-    }
-
-
 def test_get_left_get_right():
     diff = ModelDiff(apartment, apartment_two)
     assert diff.get_left('apt') == '101'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,7 +5,7 @@ from sqlalchemy.testing.schema import Column
 
 from daomodel import reference_of
 from daomodel.util import names_of, values_from_dict, filter_dict, ensure_iter, dedupe, in_order, retain_in_dict, \
-    remove_from_dict
+    remove_from_dict, mode
 from tests.conftest import Person, Book
 from tests.labeled_tests import labeled_tests
 
@@ -26,6 +26,17 @@ def test_reference_of(column: Column, expected:  str):
 ])
 def test_names_of(columns: list[Column], expected:  list[str]):
     assert names_of(columns) == expected
+
+
+@pytest.mark.parametrize('elements, expected', [
+    ([1, 2, 2, 3], 2),
+    ([1, 1, 2, 2, 3], 1),
+    (['a', 'b', 'b', 'c', 'c', 'c'], 'c'),
+    ([True, True, False, True], True),
+    ([1], 1)
+])
+def test_mode(elements: list, expected: Any):
+    assert mode(elements) == expected
 
 
 @pytest.mark.parametrize('keys, expected', [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,8 @@ import pytest
 from sqlalchemy.testing.schema import Column
 
 from daomodel import reference_of
-from daomodel.util import names_of, values_from_dict, filter_dict, MissingInput, ensure_iter, dedupe, in_order
+from daomodel.util import names_of, values_from_dict, filter_dict, ensure_iter, dedupe, in_order, retain_in_dict, \
+    remove_from_dict
 from tests.conftest import Person, Book
 from tests.labeled_tests import labeled_tests
 
@@ -37,14 +38,24 @@ def test_values_from_dict(keys: tuple[str], expected: tuple[Any]):
     assert values_from_dict(*keys, a=1, b=2, c=3) == expected
 
 
-@pytest.mark.parametrize('keys, dictionary', [
-    (('a',), {}),
-    (('b', ), {'a':1, 'c':3}),
-    (('b', 'c'), {'a':1, 'b':2})
+@pytest.mark.parametrize('keys, expected', [
+    ((), {}),
+    (('b',), {'b': 2}),
+    (('a', 'c'), {'a':1, 'c':3}),
+    (('b', 'c', 'a'), {'a':1, 'b':2, 'c':3})
 ])
-def test_values_from_dict__missing(keys: tuple[str], dictionary: dict[str, Any]):
-    with pytest.raises(MissingInput):
-        values_from_dict('missing')
+def test_retain_in_dict(keys: tuple[str], expected: tuple[Any]):
+    assert retain_in_dict({'a': 1, 'b': 2, 'c': 3}, *keys) == expected
+
+
+@pytest.mark.parametrize('keys, expected', [
+    ((), {'a':1, 'b':2, 'c':3}),
+    (('b',), {'a':1, 'c':3}),
+    (('a', 'c'), {'b': 2}),
+    (('b', 'c', 'a'), {})
+])
+def test_remove_from_dict(keys: tuple[str], expected: tuple[Any]):
+    assert remove_from_dict({'a': 1, 'b': 2, 'c': 3}, *keys) == expected
 
 
 @pytest.mark.parametrize('keys, expected', [


### PR DESCRIPTION
### Description

This pull request introduces multiple key enhancements to refine DAOModel operations and conflict resolution:

1. **BaseService Class**:
    - Provides a foundation for service layers managing DAOModels.
    - Supports model merging with conflict resolution and foreign key redirection.

2. **Improved Conflict Resolution Logic**:
    - Enhanced MergeSet conflict-handling capabilities.
    - Support for flexible, customizable resolution mechanisms in ModelDiff and ChangeSet.

3. **Removal of 'unset' Property**:
    - Simplifies property management by retiring the misunderstoood 'unset' category in favor of clarified definitions with the 'assigned' category.

4. **Utilities and Test Coverage**:
    - Added `mode` function for calculating the most frequent value in an iterable.
    - Introduced new unit tests and test suite updates enhancing correctness and coverage.

### Notable Changes
- Refactored resolution logic, model properties, and enums for consistency, clarity, and maintainability.
- Additional utility methods streamline dynamic model comparisons and value retrieval. 

These updates collectively streamline the service layer and enable improved handling of complex DAOModel scenarios while improving code clarity and maintainability.