### PR TITLE
Added Transaction Support

### DIFF
--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Self, Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import sqlalchemy
 from sqlmodel import SQLModel, Field
@@ -86,7 +86,7 @@ class DAOModel(SQLModel):
         return {fk.parent for fk in cls.__table__.foreign_keys}
 
     @classmethod
-    def get_references_of(cls, model: type[Self]) -> set[Column]:
+    def get_references_of(cls, model: type['DAOModel']) -> set[Column]:
         """Returns the Columns of this Model that represent Foreign Keys of the specified Model.
 
         :return: An unordered set of foreign key columns
@@ -174,7 +174,7 @@ class DAOModel(SQLModel):
         """
         return {column: self.get_value_of(column) for column in columns}
 
-    def compare(self, other: Self, include_pk: Optional[bool] = False) -> dict[str, tuple[Any, Any]]:
+    def compare(self, other: 'DAOModel', include_pk: Optional[bool] = False) -> dict[str, tuple[Any, Any]]:
         """Compares this model to another, producing a diff.
 
         By default, primary keys are excluded in the diff.
@@ -182,7 +182,7 @@ class DAOModel(SQLModel):
 
         :param other: The model to compare to this one
         :param include_pk: True if you want to include the primary key in the diff
-        :return: A dictionary of property names with a tuple of this instances value and the other value respectively
+        :return: A dictionary of property names with a tuple of this instance's value and the other value respectively
         """
         args = {'all': True}
         if not include_pk:
@@ -196,7 +196,7 @@ class DAOModel(SQLModel):
         return diff
 
     @classmethod
-    def get_searchable_properties(cls) -> Iterable[Column|tuple[type[Self], ..., Column]]:
+    def get_searchable_properties(cls) -> Iterable[Column|tuple[type['DAOModel'], ..., Column]]:
         """Returns all the Columns for this Model that may be searched using the DAO find function.
 
         :return: A list of searchable columns
@@ -204,7 +204,7 @@ class DAOModel(SQLModel):
         return cls.get_properties()
 
     @classmethod
-    def find_searchable_column(cls, prop: [str|Column], foreign_tables: list[type[Self]]) -> Column:
+    def find_searchable_column(cls, prop: [str|Column], foreign_tables: list[type['DAOModel']]) -> Column:
         """Returns the specified searchable Column.
 
         :param prop: str type reference of the Column or the Column itself
@@ -235,7 +235,7 @@ class DAOModel(SQLModel):
         """
         return dict(zip(cls.get_pk_names(), *pk_values))
 
-    def copy_model(self, source: Self, *fields: str) -> None:
+    def copy_model(self, source: 'DAOModel', *fields: str) -> None:
         """Copies values from another instance of this Model.
 
         Unless the fields are specified, all but PK are copied.
@@ -263,7 +263,7 @@ class DAOModel(SQLModel):
         for k, v in values.items():
             setattr(self, k, v)
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: 'DAOModel') -> bool:
         """Instances are determined to be equal based on only their primary key."""
         return self.get_pk_values() == other.get_pk_values() if type(self) == type(other) else False
 

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -133,16 +133,16 @@ class DAOModel(SQLModel):
         for key, value in kwargs.items():
             if key not in property_categories:
                 raise ValueError(f'Unexpected keyword argument {key} is not one of {property_categories}')
-            if key is 'all':
+            if key == 'all':
                 props = all_properties
-            elif key in 'pk':
+            elif key == 'pk':
                 props = self.get_pk_names()
-            elif key is 'fk':
+            elif key == 'fk':
                 props = names_of(self.get_fk_properties())
-            elif key is 'assigned':
+            elif key == 'assigned':
                 props = self.model_dump(exclude_defaults=True, exclude_none=True)
             else:
-                if key is 'standard':
+                if key == 'standard':
                     exclude = self.get_pk_names() + names_of(self.get_fk_properties())
                 else:
                     exclude = self.model_dump(**{f'exclude_{key}': True})

--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -61,7 +61,7 @@ class DAOModel(SQLModel):
 
         :return: A tuple of primary key values
         """
-        return tuple(list(getattr(self, key) for key in names_of(self.get_pk())))
+        return tuple(getattr(self, key) for key in names_of(self.get_pk()))
 
     def get_pk_dict(self) -> dict[str, Any]:
         """Returns the dictionary Primary Keys for this instance of the Model.

--- a/daomodel/dao.py
+++ b/daomodel/dao.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Any, TypeVar, Self, Iterable, Iterator
+from typing import Optional, Any, TypeVar, Iterable, Iterator
 
 from sqlalchemy import func, Column, text, UnaryExpression
 from sqlalchemy.orm import Session
@@ -36,7 +36,7 @@ class SearchResults(list[T]):
     def __iter__(self) -> Iterator[T]:
         return iter(self.results)
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: 'SearchResults') -> bool:
         return (self.results == other.results
                 and self.total == other.total
                 and self.page == other.page
@@ -245,7 +245,7 @@ class DAO:
                     .alias(alias))
         return query.join(subquery, column == text(f"{alias}.{column.name}"))
 
-    def _filter(self, query: Query, key: [str|Column], value: Any, foreign_tables: list[type[Self]]) -> Query:
+    def _filter(self, query: Query, key: [str|Column], value: Any, foreign_tables: list[type[DAOModel]]) -> Query:
         column = self.model_class.find_searchable_column(key, foreign_tables)
         return query.filter(value.get_expression(column) if isinstance(value, ConditionOperator) else column == value)
 

--- a/daomodel/dao.py
+++ b/daomodel/dao.py
@@ -62,6 +62,20 @@ class DAO:
     def __init__(self, model_class: type[T], db: Session):
         self.model_class = model_class
         self.db = db
+        self._auto_commit = True
+
+    def start_transaction(self) -> None:
+        """Starts a transaction by setting transaction_mode to True.
+
+        This disables auto_commit and autoflush until the transaction is
+        committed or rolled back.
+        """
+        self._auto_commit = False
+        self.db.autoflush = False
+
+    def _end_transaction(self) -> None:
+        self._auto_commit = True
+        self.db.autoflush = True
 
     @property
     def query(self) -> Query[Any]:
@@ -80,17 +94,17 @@ class DAO:
         """
         return self.create_with(**self.model_class.pk_values_to_dict(pk_values))
 
-    def create_with(self, commit: bool = True, **values: Any) -> T:
+    def create_with(self, insert: bool = True, **values: Any) -> T:
         """Creates a new entry for the given primary key and property values.
 
-        :param commit: False to avoid adding the model to the database at this time
+        :param insert: False to avoid adding the model to the database
         :param values: The values to assign to the model
         :return: The new DAOModel
-        :raises: Conflict if an entry already exists for the primary key
+        :raises: Conflict if an entry already exists for the primary key (does not apply if insert=False)
         """
         model = self.model_class(**filter_dict(*self.model_class.get_pk_names(), **values))
         model.set_values(ignore_pk=True, **values)
-        if commit:
+        if insert:
             self.insert(model)
         return model
 
@@ -103,19 +117,9 @@ class DAO:
         if self.exists(model):
             raise Conflict(model)
         self.db.add(model)
-        self.commit()
-        self.db.refresh(model)
-
-    def update(self, model: T) -> None:
-        """Updates the database to align with the provided model.
-
-        :param model: The existing DAOModel entry to update in the database
-        :raises NotFound: if the model does not exist in the database
-        """
-        if not self.exists(model):
-            raise NotFound(model)
-        self.commit()
-        self.db.refresh(model)
+        if self._auto_commit:
+            self.commit()
+            self.db.refresh(model)
 
     def upsert(self, model: T) -> None:
         """Updates the given model in the database or creates it if it does not exist.
@@ -123,9 +127,9 @@ class DAO:
         :param model: The DAOModel entry which may or may not exist
         """
         try:
-            self.update(model)
-        except NotFound:
             self.insert(model)
+        except Conflict:
+            self.commit()
         return model
 
     def rename(self, existing: T, *new_pk_values: Any) -> None:
@@ -140,7 +144,7 @@ class DAO:
         except NotFound:
             for k, v in zip(existing.get_pk_names(), new_pk_values):
                 setattr(existing, k, v)
-            self.update(existing)
+            self._commit_if_not_transaction()
 
     def exists(self, model: T) -> bool:
         """Determines if a model exists in the database.
@@ -254,23 +258,50 @@ class DAO:
         """
         return query
 
-    def remove(self, model: T, commit: bool = True) -> None:
+    def remove(self, model: T) -> None:
         """Deletes the given model entry from the database.
 
         :param model: The DAOModel object to be deleted
-        :param commit: False to not yet commit
         :raises NotFound: if the model does not exist in the database
         """
         if self.exists(model):
             self.db.delete(model)
         else:
             raise NotFound(model)
-        if commit:
+        self._commit_if_not_transaction()
+
+    def _commit_if_not_transaction(self):
+        if self._auto_commit:
             self.commit()
 
-    def commit(self) -> None:
+    def commit(self, *models_to_refresh: DAOModel) -> None:
         """Commits all pending changes to the database.
 
-        Following commit, DAOModels will need to be refreshed.
+        'Pending changes' includes data changes made to models that were fetched from the database.
+        Use dao.start_transaction() to avoid automatically calling this method following each insert, upsert, and remove.
+        This will commit all changes within the session and is not limited to this DAO.
+        Following the DB commit, DAOModels will be detached, needing to be refreshed.
+
+        If this DAO was in transaction mode, it will be reset to auto-commit mode after committing.
+
+        :param models_to_refresh: The DAOModels to refresh after committing
+        raises: NotFound if a model does not exist in the database
         """
         self.db.commit()
+        for model in models_to_refresh:
+            if not self.exists(model):
+                raise NotFound(model)
+            self.db.refresh(model)
+        self._end_transaction()
+
+    def rollback(self) -> None:
+        """Rolls back all pending database changes of a transaction.
+
+        This will discard all changes that have not yet been committed.
+
+        :raises RuntimeError: if not in transaction mode
+        """
+        if self._auto_commit:
+            raise RuntimeError("Cannot rollback while not in transaction mode")
+        self.db.rollback()
+        self._end_transaction()

--- a/daomodel/dao.py
+++ b/daomodel/dao.py
@@ -209,15 +209,13 @@ class DAO:
         query = query.order_by(*order)
         query = self.filter_find(query, **filters)
 
-        print(query)
-
         total = query.count()
-        if page or per_page:
-            if not page:
+        if per_page:
+            if not page or page < 1:
                 page = 1
-            elif not per_page:
-                raise MissingInput("Must specify how many results per page")
             query = query.offset((page - 1) * per_page).limit(per_page)
+        elif page:
+            raise MissingInput("Must specify how many results per page")
 
         return SearchResults(query.all(), total, page, per_page)
 

--- a/daomodel/db.py
+++ b/daomodel/db.py
@@ -1,4 +1,4 @@
-from typing import Optional, Self
+from typing import Optional
 
 import sqlalchemy
 from sqlalchemy import Engine, event
@@ -51,7 +51,7 @@ class DAOFactory:
     def __init__(self, session_factory: sessionmaker):
         self.session_factory = session_factory
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> 'DAOFactory':
         self.db = self.session_factory()
         return self
 

--- a/daomodel/model_diff.py
+++ b/daomodel/model_diff.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Optional, Self, Callable
+from typing import Any, Optional, Callable
 
 from daomodel import DAOModel
 from daomodel.dao import Conflict
@@ -244,7 +244,7 @@ class ChangeSet(ModelDiff):
             resolution
         )
 
-    def resolve_preferences(self) -> Self:
+    def resolve_preferences(self) -> 'ChangeSet':
         """Removes unwanted changes, preserving the meaningful values, regardless of them being from baseline or target
 
         :return: This ChangeSet to allow for chaining function calls

--- a/daomodel/util.py
+++ b/daomodel/util.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import Iterable, Any, OrderedDict
+from functools import wraps
+from typing import Iterable, Any, OrderedDict, Callable
 
 from sqlalchemy import Column, ColumnElement
 from sqlmodel import or_, and_
@@ -130,6 +131,18 @@ def in_order(original: Iterable, order: list) -> list:
     :return: a new list of the items following the defined order
     """
     return [item for item in order if item in original]
+
+
+def kwargs_if_none_provided(**default_kwargs: Any) -> Callable:
+    """A decorator to provide default values into `**kwargs` only if `kwargs` is empty."""
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if not kwargs:
+                kwargs = default_kwargs
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 
 def next_id() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ authors = [{name="Cody M Sommer", email="bassmastacod@gmail.com"}]
 description = "Provides an automatic DAO layer for your models"
 keywords = ["dao", "crud", "model", "database", "db", "search", "query", "sql", "sqlmodel", "sqlalchemy", "pydantic"]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = ["sqlalchemy", "sqlmodel", "str_case_util"]
 license = {text = "MIT"}
 classifiers = [
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,11 @@ authors = [{name="Cody M Sommer", email="bassmastacod@gmail.com"}]
 description = "Provides an automatic DAO layer for your models"
 keywords = ["dao", "crud", "model", "database", "db", "search", "query", "sql", "sqlmodel", "sqlalchemy", "pydantic"]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["sqlalchemy", "sqlmodel", "str_case_util"]
 license = {text = "MIT"}
 classifiers = [
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/tests/test_dao.py
+++ b/tests/test_dao.py
@@ -1,7 +1,7 @@
 import pytest
 
 from daomodel.dao import DAO, NotFound, Conflict
-from daomodel.util import MissingInput
+from daomodel.util import MissingInput, next_id
 from tests.conftest import TestDAOFactory, Student, Person, Book
 
 
@@ -35,8 +35,16 @@ def test_create_with(daos: TestDAOFactory):
     daos.assert_in_db(Student, 100, name='Bob', active=False)
 
 
-def test_create_with__no_commit(daos: TestDAOFactory):
+def test_create_with__no_insert(daos: TestDAOFactory):
     model = daos[Student].create_with(False, id=100)
+    assert model == Student(id=100)
+    daos.assert_not_in_db(Student, 100)
+
+
+def test_create_with__no_commit(daos: TestDAOFactory):
+    dao = daos[Student]
+    dao.start_transaction()
+    model = dao.create_with(id=100)
     assert model == Student(id=100)
     daos.assert_not_in_db(Student, 100)
 
@@ -59,22 +67,6 @@ def test_insert__conflict(daos: TestDAOFactory):
     daos.assert_in_db(Student, 100)
     with pytest.raises(Conflict):
         dao.insert(Student(id=100))
-
-
-def test_update(daos: TestDAOFactory):
-    dao = daos[Student]
-    model = Student(id=100)
-    dao.insert(model)
-    assert model.name is None
-    model.name = 'Bob'
-    daos.assert_in_db(Student, 100, name=None)
-    dao.update(model)
-    daos.assert_in_db(Student, 100, name='Bob')
-
-
-def test_update_missing(daos: TestDAOFactory):
-    with pytest.raises(NotFound):
-        daos[Student].update(Student(id=100, name='Bob'))
 
 
 def test_upsert__new(daos: TestDAOFactory):
@@ -160,32 +152,34 @@ def test_rename__already_exists(daos: TestDAOFactory):
         dao.rename(model, 200)
 
 
-def test_exists_true(daos: TestDAOFactory):
+def test_exists__true(daos: TestDAOFactory):
     dao = daos[Student]
     model = dao.create(100)
     assert dao.exists(model)
 
 
-def test_exists_false(daos: TestDAOFactory):
+def test_exists__false(daos: TestDAOFactory):
     dao = daos[Student]
-    model = dao.create_with(id=100, commit=False)
+    model = dao.create_with(id=100, insert=False)
     assert not dao.exists(model)
 
 
 def test_get__single_column(daos: TestDAOFactory):
     dao = daos[Student]
     dao.create_with(id=100, name='Bob')
-    model = DAO(Student, daos.assert_session).get(100)
-    assert model.id == 100
-    assert model.name == 'Bob'
+    with daos.session_factory() as fresh_session:
+        model = DAO(Student, fresh_session).get(100)
+        assert model.id == 100
+        assert model.name == 'Bob'
 
 
 def test_get__multiple_column(daos: TestDAOFactory):
     dao = daos[Person]
     dao.create_with(name='John', age=23)
-    model = DAO(Person, daos.assert_session).get('John', 23)
-    assert model.name == 'John'
-    assert model.age == 23
+    with daos.session_factory() as fresh_session:
+        model = DAO(Person, fresh_session).get('John', 23)
+        assert model.name == 'John'
+        assert model.age == 23
 
 
 def test_get__missing_column(daos: TestDAOFactory):
@@ -201,25 +195,28 @@ def test_get__not_found(daos: TestDAOFactory):
 def test_get_with(daos: TestDAOFactory):
     dao = daos[Student]
     dao.create_with(id=100, name='Bob')
-    model = DAO(Student, daos.assert_session).get_with(id=100, name='Mike')
-    assert model.id == 100
-    assert model.name == 'Mike'
+    with daos.session_factory() as fresh_session:
+        model = DAO(Student, fresh_session).get_with(id=100, name='Mike')
+        assert model.id == 100
+        assert model.name == 'Mike'
 
 
 def test_get_with__no_additional_data(daos: TestDAOFactory):
     dao = daos[Student]
     dao.create_with(id=100, name='Bob')
-    model = DAO(Student, daos.assert_session).get_with(id=100)
-    assert model.id == 100
-    assert model.name == 'Bob'
+    with daos.session_factory() as fresh_session:
+        model = DAO(Student, fresh_session).get_with(id=100)
+        assert model.id == 100
+        assert model.name == 'Bob'
 
 
 def test_get_with__blank_data(daos: TestDAOFactory):
     dao = daos[Student]
     dao.create_with(id=100, name='Bob')
-    model = DAO(Student, daos.assert_session).get_with(id=100, name=None)
-    assert model.id == 100
-    assert model.name is None
+    with daos.session_factory() as fresh_session:
+        model = DAO(Student, fresh_session).get_with(id=100, name=None)
+        assert model.id == 100
+        assert model.name is None
 
 
 def test_get__missing_data(daos: TestDAOFactory):
@@ -248,7 +245,53 @@ def test_remove__not_found(daos: TestDAOFactory):
 def test_commit(daos: TestDAOFactory):
     dao = daos[Student]
     model = dao.create(100)
-    dao.remove(model, commit=False)
-    daos.assert_in_db(Student, 100)
+    model.active = False
+    daos.assert_in_db(Student, 100, active=True)
     dao.commit()
+    daos.assert_in_db(Student, 100, active=False)
+
+
+def test_commit__refresh(daos: TestDAOFactory):
+    dao = daos[Student]
+    dao.create(100)
+    dao.start_transaction()
+    model = dao.create_with(id=next_id())
+    dao.commit(model)
+    assert model.id is 101
+
+
+def test_commit__missing(daos: TestDAOFactory):
+    dao = daos[Student]
+    model = dao.create(100)
+    dao.start_transaction()
+    dao.remove(model)
+    with pytest.raises(NotFound):
+        dao.commit(model)
+
+
+def test_transaction(daos: TestDAOFactory):
+    dao = daos[Student]
+    dao.start_transaction()
+    dao.create_with(id=100, name='Billy')
+    daos.assert_not_in_db(Student, 100)
+    dao.create_with(id=101, name='Bob')
+    daos.assert_not_in_db(Student, 100)
+    daos.assert_not_in_db(Student, 101)
+
+    dao.commit()
+    daos.assert_in_db(Student, 100, name='Billy')
+    daos.assert_in_db(Student, 101, name='Bob')
+
+
+def test_transaction__rollback(daos: TestDAOFactory):
+    dao = daos[Student]
+    dao.start_transaction()
+    dao.create_with(id=100, name='Alice')
+    daos.assert_not_in_db(Student, 100)
+    dao.rollback()
+    daos.assert_not_in_db(Student, 100)
+
+    dao.create_with(id=101, name='Bob')
+    dao.commit()
+    daos.assert_in_db(Student, 101, name='Bob')
     daos.assert_not_in_db(Student, 100)

--- a/tests/test_get_property_names.py
+++ b/tests/test_get_property_names.py
@@ -156,7 +156,6 @@ primary_key_and_none_value_foreign_key_property_values = {
 
 @labeled_tests({
     'no properties': [
-        ({}, {}),
         ({'all': False}, {}),
         ({'pk': False}, {}),
         ({'assigned': False}, {}),
@@ -165,6 +164,7 @@ primary_key_and_none_value_foreign_key_property_values = {
         ({'pk': False, 'assigned': False, 'defaults': False, 'none': False}, {})
     ],
     'all properties': [
+        ({}, all_property_values),
         ({'all': True}, all_property_values),
         ({'pk': True, 'fk': True, 'standard': True}, all_property_values)
     ],


### PR DESCRIPTION
### Improvements
- Implemented transactional support in the DAO with `start_transaction`, `commit`, and `rollback` methods.
- Added `kwargs_if_none_provided` decorator for streamlined default `**kwargs` handling.
- Simplified primary key tuple generation for better readability and efficiency.

### Fixes
- Replaced `Self` with explicit class names in type hints to ensure 3.10 support.
- Addressed pagination to default to the first page if an invalid or zero value is provided.
- Fixed incorrect use of `is` for string comparisons, switching to `==`.