### PR TITLE
Add dependencies for Read the Docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,7 @@ build:
 
 mkdocs:
   configuration: mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-same-dir


### PR DESCRIPTION
Added a `docs/requirements.txt` file to specify Python dependencies for building documentation. Updated `.readthedocs.yaml` to reference this requirements file, ensuring consistent environment setup.