### PR TITLE
Added documentation for DAO

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,31 @@ An instant CRUD layer for your Python models (Powered by
 [Pydantic](https://docs.pydantic.dev/latest/) /
 [SQLAlchemy](https://www.sqlalchemy.org/)).
 
-Eliminate repetitive work by auto-creating your DAOs.
-There is no need to write SQL queries or recall how to work with
-SQLAlchemy models when you are only looking to do basic functionality.
+* Eliminate repetitive work by auto-creating your DAOs
+* Make your code more straightforward and readable
+* Write less code, meaning:
+    * have a usable product sooner
+    * less testing
+    * less potential for bugs
 
-## Supported Functions
-* `create`
-* `insert`
-* `update` (commit changes made to an entry)
-* `upsert`
-* `rename` (change the primary key values of an entry)
-* if `exists`
-* `get`
-* `find` (supports advanced searching, more details below)
-* `remove`
-* access to `query` (to do anything else not directly supported)
+## Purpose
+Assembled from a collection of duplicated logic found across several projects,
+this library serves as a starting point for your database-backed Python project.
+Though great for complex apps, it's also a great starting point for simple projects.
+DAOModel will benefit new developers the most by providing a straight forward start to writing code.
+
+A goal of my libraries is to remove upfront hurdles to facilitate learning along the way.
+Following the [Guides](https://daomodel.readthedocs.io/en/latest/docs/getting_started/),
+anyone can get started without knowledge of relational databases or SQLAlchemy.
+If any documentation or design is unclear,
+please [submit a ticket](https://github.com/BassMastaCod/DAOModel/issues/new)
+so that I can be sure that even beginners are able to benefit from this project.
 
 ## Features
-* DAOModel expands upon SQLModel so no need to learn a new way to define your models.
-* Existing SQLModel, Pydantic, and SQLAlchemy functionality is still accessible for anything not built into DAOModel.
-* Provides many quality-of-life additions that I found to be repeated throughout my own projects.
+* Expands upon SQLModel; works with your existing models
+* SQLAlchemy under the hood; keep existing logic while using DAOModel functions for new code
+* Advanced search capabilities without raw SQL
+* Quality-of-life additions
 
 Looking for more? Check out my other projects on [GitHub](https://github.com/BassMastaCod)
 
@@ -39,16 +44,20 @@ or, given that this project is a development tool, you will likely add _DAOModel
 Next, move on to the [Getting Started](https://daomodel.readthedocs.io/en/latest/docs/getting_started/) page to begin developing your DAOModels.
 
 ## Caveats
+
+### Database Support
 Most testing has been completed using SQLite, though since SQLModel/SQLAlchemy
 support other database solutions, DAOModel is expected to as well.
 
 Speaking of SQLite, this library configures Foreign Key constraints to be enforced by default in SQLite.
 
+### Table Names
 Table names are configured to be snake_case which differs from SQLModel.
 This can be adjusted by overriding `def __tablename__` in your own child class.
 
+### Unsupported Functionality
 Not all functionality will work as intended through DAOModel.
-If something isn't supported, submit a ticket or pull request.
+If something isn't supported, [submit a ticket](https://github.com/BassMastaCod/DAOModel/issues/new) or pull request.
 And remember that you may always use what you can and then
 override the code or use the query method in DAO to do the rest.
 It should still save you a lot of lines of code.

--- a/daomodel/util.py
+++ b/daomodel/util.py
@@ -12,6 +12,14 @@ class MissingInput(Exception):
         self.detail = detail
 
 
+class InvalidArgumentCount(Exception):
+    """Indicates that an incorrect number of arguments was provided."""
+    def __init__(self, expected: int, got: int, context: str = None):
+        self.detail = f'Expected {expected} values, got {got}'
+        if context:
+            self.detail += f' for {context}'
+
+
 def reference_of(column: Column) -> str:
     """
     Prepares a str reference of a column.
@@ -146,7 +154,7 @@ def kwargs_if_none_provided(**default_kwargs: Any) -> Callable:
 
 
 def next_id() -> None:
-    """Indicates to the model that an id should be auto incremented"""
+    """Indicates to the model that an id should be auto-incremented"""
     return None
 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -33,7 +33,7 @@ Otherwise, you may find some of the library's built-in functionality useful.
 ### Create your engine using DAOModel's helper function
 
 ```python
-engine = create_engine("database.db")
+engine = create_engine('database.db')
 ```
 
 This uses **SQLite** to store your data. If you don't need persistence,
@@ -90,11 +90,16 @@ So there you have it, You now have a usable DAO layer for your model!
 Let's look at the full code:
 
 ```python
+from sqlmodel import Field, Session
+from daomodel import DAOModel, DAO
+from daomodel.db import create_engine, init_db
+
+
 class Customer(DAOModel, table=True):
     id: int = Field(primary_key=True)
     name: str
 
-engine = create_engine("database.db")
+engine = create_engine('database.db')
 init_db(engine)
 db = Session(engine)
 dao = DAO(Customer, db)
@@ -106,4 +111,4 @@ Just a few lines is all you need to get started!
 ## Next Steps
 
 Now that you have set up your model and DAO, you can start using the DAO to interact with your database.
-Continue to the [Using the DAO](using_dao.md) section to learn more about the available operations.
+Continue to the [Using the DAO](usage/dao.md) section to learn more about the available operations.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-same-dir
+mkdocstrings[python]

--- a/docs/usage/dao.md
+++ b/docs/usage/dao.md
@@ -1,0 +1,245 @@
+# Using the DAO
+
+The [previous page](../getting_started.md) concluded with access to a DAO instance.
+This page explains the basic operations available through your new DAO interface.
+
+For the examples on this page, we'll assume the following sample DAOs.
+```python
+from daomodel import DAO, DAOModel
+from daomodel.model import PrimaryKey
+
+class Customer(DAOModel, table=True):
+    id: int = PrimaryKey
+    name: str
+    email: str
+
+# Model with a composite primary key
+class OrderDetail(DAOModel, table=True):
+    order_id: int = PrimaryKey
+    line_number: str = PrimaryKey
+    product_code: bytes = PrimaryKey
+    quantity: int
+
+dao = DAO(Customer, db)
+order_dao = DAO(OrderDetail, db)
+```
+
+## CRUD Operations
+
+The DAO class provides a complete set of **C**reate, **R**ead, **U**pdate, and **D**elete operations for your DAOModel instances.
+These operations make it easy to interact with your database without writing complex SQL queries.
+
+### Create
+
+Creating new records in your database is straightforward with the DAO.
+
+::: daomodel.dao.DAO.create
+```python
+# Create a new customer with just the primary key
+customer = dao.create(1)  # Creates a Customer with id=1
+
+order = order_dao.create(42, 'A123', b'PRD001') # Creates a OrderDetail having multiple primary key values
+```
+
+If you wish to set more properties than just the primary key, you will want to use the `create_with` method.
+
+::: daomodel.dao.DAO.create_with
+```python
+# Create a customer with specific values
+customer = dao.create_with(id=3, name='John Smith', email='john@example.com')
+```
+> **Note:** The `create_with` method requires keyword arguments for the primary key values.
+
+If you wish to create a model without adding it to the database, you can set the `insert` parameter to False.
+
+```python
+# Create without adding to the database
+customer = dao.create_with(id=4, name='Guest User', insert=False)
+```
+
+If using `insert=False` you will then need to explicitly call `insert` if you wish to add the row to the DB.
+
+::: daomodel.dao.DAO.insert
+```python
+# Create a model without inserting it
+customer = dao.create_with(id=5, name='Alice Brown', email='alice@example.com', insert=False)
+
+# Insert it into the database
+dao.insert(customer)
+```
+
+After adding to the database, you will now be able to read the data.
+
+### Read
+
+The DAO provides several methods to retrieve data from your database.
+
+::: daomodel.dao.DAO.get
+```python
+# Get a customer by primary key
+customer = dao.get(1)  # Gets Customer with id=1
+
+# Get an order detail with a composite primary key
+order = order_dao.get(42, 'A123', b'PRD001')  # Again, order must match the model definition
+```
+
+The `get_with` method expands upon `get` by optionally applying additional values.
+
+::: daomodel.dao.DAO.get_with
+```python
+# Get a customer with modified properties
+customer = dao.get_with(id=1, name='Updated Name')
+```
+> **Note:** The `get_with` method requires keyword arguments for the primary key values.
+
+If you do not know the primary key values, you can search for a record based on other properties.
+
+::: daomodel.dao.DAO.find
+Searching is covered in more detail on the [Search](#search) page.
+
+If you just want to know if a model is in the DB, the `exists` method can help with that.
+
+::: daomodel.dao.DAO.exists
+```python
+# Check if a customer exists by creating a temporary instance
+temp_customer = Customer(id=1)
+if dao.exists(temp_customer):
+    print('Customer exists!')
+```
+> **Note:** If you don't have the model instance, a `get` call within a `try` block may be simpler.
+
+### Update
+
+The DAO provides methods to easily update existing records.
+
+::: daomodel.dao.DAO.commit
+```python
+# Get a customer and update it
+customer = dao.get(1)
+customer.name = 'New Name'
+dao.commit()  # Save changes
+
+# Or use get_with to update in less steps
+customer = dao.get_with(id=1, name='Another Name')
+dao.commit(customer)  # Save changes and refresh the model reference to continue using it
+print(customer.name)
+```
+
+Alternatively, you can use the `upsert` method to store the updated record regardless of if it exists.
+
+::: daomodel.dao.DAO.upsert
+```python
+# Create a model that may or may not exist
+customer = Customer(id=10, name="Maybe New", email="maybe@example.com")
+
+# Upsert it - will create if id=10 doesn't exist, or update if it does
+dao.upsert(customer)
+```
+
+If it is the primary key values you need to change, both `commit` and `upsert` may not work as you intend.
+The `rename` method handles this for you.
+
+::: daomodel.dao.DAO.rename
+```python
+# Get an existing customer
+customer = dao.get(1)
+
+# Rename (change primary key)
+dao.rename(customer, 100)  # Changes id from 1 to 100
+
+# With composite keys, pass all primary key values in order
+order = order_dao.get(42, 'A123', b'PRD001')
+order_dao.rename(order, 43, 'A123', b'PRD002')  # Changes order_id, and product_code
+```
+
+### Delete
+
+Finally, if you need to delete a record, the DAO provides that method too.
+
+::: daomodel.dao.DAO.remove
+```python
+# Get a customer
+customer = dao.get(1)
+
+# Remove it
+dao.remove(customer)
+
+# Or remove using a temporary instance
+dao.remove(Customer(id=2))  # raises NotFound if it isn't in the database
+```
+
+## Transactions
+
+The DAO supports transactions to ensure data integrity when performing multiple operations. A transaction is a sequence
+of database operations that are treated as a single unit of work. Either all operations within the transaction are
+completed successfully (committed), or none of them are (rolled back). This ensures data consistency and helps maintain
+the integrity of your database.
+
+For example, if you're transferring money between two accounts, you want both the withdrawal and deposit to either
+succeed or fail together - you don't want one to happen without the other. Transactions provide this "all-or-nothing"
+guarantee.
+
+To enter _transaction mode_, use the `start_transaction` method.
+
+::: daomodel.dao.DAO.start_transaction
+```python
+# Start a transaction
+dao.start_transaction()
+
+try:
+    # Perform multiple operations
+    customer1 = dao.create_with(id=1, name="Transaction Test 1")
+    customer2 = dao.create_with(id=2, name="Transaction Test 2")
+    
+    # Commit the transaction
+    dao.commit()
+except Exception as e:
+    # Rollback on error
+    dao.rollback()
+    print(f"Transaction failed: {e}")
+```
+
+#### commit
+As you can see above, [commit()](#update) is how you finalize a transaction.
+It saves all pending changes to the database and exits transaction mode.
+If you wish to follow up with an additional transaction, you can call `start_transaction` again.
+If you wish to back out of all changes instead of committing them, you can see that is done through a rollback.
+
+::: daomodel.dao.DAO.rollback
+```python
+dao.start_transaction()
+
+# Make some changes
+customer = dao.create_with(id=100, name="Will be rolled back")
+
+# Decide to cancel these changes
+dao.rollback()
+
+# The customer won't be in the database
+try:
+    dao.get(100)  # This will raise NotFound
+except NotFound:
+    print("Customer was not created due to rollback")
+```
+
+## Query
+
+The DAO provides access to SQLAlchemy's powerful query interface for other, unsupported operations.
+
+```python
+query = dao.query
+
+# Example: Update all customers with '@example.com' email to have 'Example Customer' as their name
+query.filter(Customer.email.like('%@example.com')).update(
+    {"name": "Example Customer"},
+    synchronize_session=False
+)
+
+# Don't forget to commit the changes
+dao.commit()
+```
+
+## Next Steps
+
+Now that you understand how to use the DAO, let's move on to the [Model](model.md) on the next page
+before diving into some more [advanced features](advanced_features.md) such as [Search](search.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,10 +2,26 @@ site_name: DAOModel
 docs_dir: .
 
 nav:
-  - Home: README.md
-  - Getting Started: docs/getting_started.md
+- Home: README.md
+- Getting Started: docs/getting_started.md
+- DAO: docs/usage/dao.md
 
 theme: readthedocs
 
 plugins:
-  - same-dir
+- same-dir
+- search
+- mkdocstrings:
+    handlers:
+      python:
+        options:
+          show_source: false
+          heading_level: 4
+          show_root_heading: true
+          show_root_full_path: false
+          separate_signature: true
+          show_signature_annotations: true
+          docstring_style: sphinx
+          docstring_section_style: spacy
+          show_root_members_full_path: false
+          members_order: source


### PR DESCRIPTION
Improved the readthedocs documentation by including a page for the dao functionality. This page covers the basic CRUD operations as well as transactions. The search features are mentioned but will be covered more on their own page. This paves the way for writing documentation for the defining models. Other cleanup and docs corrections were made. Search functionality was also added to readthedocs.