### PR TITLE
Filter out private fields from `fields` property

### DIFF
--- a/daomodel/metaclass.py
+++ b/daomodel/metaclass.py
@@ -61,7 +61,8 @@ class ClassDictHelper:
 
     @property
     def fields(self) -> list[Annotation]:
-        return [Annotation(field_name, field_type) for field_name, field_type in self.annotations.items()]
+        return [Annotation(field_name, field_type) for field_name, field_type in self.annotations.items() if
+                not field_name.startswith('_')]
 
     def add_unsearchable(self, field: Annotation) -> None:
         """Mark a field as unsearchable within in the class dictionary."""


### PR DESCRIPTION
This pull request ensures that private fields (fields starting with an underscore `_`) are excluded from the `fields` property. These fields are not processed as columns by SQLModel, and thus, DAOModel will align with this behavior by ignoring them.