### PR TITLE
Filter out private fields from annotations in `fields` property

### DIFF
--- a/daomodel/metaclass.py
+++ b/daomodel/metaclass.py
@@ -61,7 +61,8 @@ class ClassDictHelper:
 
     @property
     def fields(self) -> list[Annotation]:
-        return [Annotation(field_name, field_type) for field_name, field_type in self.annotations.items()]
+        return [Annotation(field_name, field_type) for field_name, field_type in self.annotations.items() if
+                not field_name.startswith('_')]
 
     def add_unsearchable(self, field: Annotation) -> None:
         """Mark a field as unsearchable within in the class dictionary."""


### PR DESCRIPTION
This pull request ensures that private fields (those starting with an underscore `_`) are excluded from the `fields` property to align with SQLModel behavior. This prevents unnecessary processing of private fields as columns in DAOModel.