### PR TITLE
Adjust typing to be more correct

### DIFF
--- a/daomodel/__init__.py
+++ b/daomodel/__init__.py
@@ -42,7 +42,7 @@ class DAOModel(SQLModel, metaclass=DAOModelMetaclass):
         return Case.TITLE_CASE.format(cls.__name__)
 
     @classmethod
-    def get_pk(cls) -> list[Column]:
+    def get_pk(cls) -> Iterable[Column]:
         """Returns the Columns that comprise the Primary Key for this Model.
 
         :return: A list of primary key columns


### PR DESCRIPTION
The typing of `list` was not accurate. The type is indeed iterable, but not always as a list. This typing was updated to help avoid runtime errors.