### PR TITLE
Added support for no_case_str

### DIFF
--- a/daomodel/fields.py
+++ b/daomodel/fields.py
@@ -74,6 +74,11 @@ class ReferenceTo(FieldInfo):
         super().__init__(**kwargs)
 
 
+class no_case_str(str):
+    """Marker type for a case-insensitive string column."""
+    pass
+
+
 def utc_now():
     """Returns the current UTC time with timezone information."""
     return datetime.now(timezone.utc)

--- a/daomodel/metaclass.py
+++ b/daomodel/metaclass.py
@@ -2,10 +2,10 @@ from typing import Dict, Any, Tuple, Type, get_origin, get_args, Union, Optional
 import inspect
 import uuid
 from sqlmodel.main import SQLModelMetaclass, Field, FieldInfo, RelationshipInfo
-from sqlalchemy import ForeignKey, JSON
+from sqlalchemy import ForeignKey, JSON, String
 
 from daomodel.util import reference_of, UnsupportedFeatureError
-from daomodel.fields import Identifier, Unsearchable, Protected, ReferenceTo
+from daomodel.fields import no_case_str, Identifier, Unsearchable, Protected, ReferenceTo
 
 
 class Annotation:
@@ -123,6 +123,9 @@ class DAOModelMetaclass(SQLModelMetaclass):
             field['default_factory'] = uuid.uuid4
         elif field.type is dict:
             field['sa_type'] = JSON
+        elif field.type is no_case_str:
+            field.type = str
+            field['sa_type'] = String(collation='NOCASE')
         elif model.is_reference(field) or field.is_dao_model():
             cls._process_reference_field(field, model)
 

--- a/docs/usage/model.md
+++ b/docs/usage/model.md
@@ -122,7 +122,7 @@ class Song(SQLModel, table=True):
 
 class User(SQLModel, table=True):
     __tablename__ = 'user'
-    username: str = Field(primary_key=True)
+    username: str = Field(primary_key=True, sa_type=String(collation='NOCASE'))
     email: str = Field(unique=True)
     favorite_song: Optional[int] = Field(
         sa_column=Column(
@@ -258,6 +258,20 @@ class Song(DAOModel, table=True):
 > **Note:** SQLModel has many more great QoL features over SQLAlchemy.
 > If you were unaware of this one, I recommend you read up on its [Features](https://sqlmodel.tiangolo.com/features/).
 
+### Case-Insensitive Strings
+```diff
+- username: str = Field(primary_key=True, sa_type=String(collation='NOCASE'))
++ username: no_case_str = Field(primary_key=True)
+```
+
+DAOModel supports automatic collation for case-insensitive string matching using the no_case_str marker type.
+Whenever DAOModel sees a field type of no_case_str, it automatically configures the database column to use
+COLLATE NOCASE (or the equivalent collation clause for your database).
+This allows you to query string fields without worrying about case sensitivity.
+```python
+class User(DAOModel, table=True):
+    username: no_case_str = Field(primary_key=True)
+```
 
 ### Model References
 ```diff
@@ -446,7 +460,7 @@ from enum import Enum
 from typing import Optional
 from uuid import UUID
 from daomodel import DAOModel
-from daomodel.fields import Identifier, Protected, CurrentTimestampField, AutoUpdatingTimestampField, Field, ReferenceTo
+from daomodel.fields import no_case_str, Identifier, Protected, CurrentTimestampField, AutoUpdatingTimestampField, Field, ReferenceTo
 
 class SubscriptionTier(Enum):
     BASIC = 'basic'
@@ -475,7 +489,7 @@ class Song(DAOModel, table=True):
     track_details: dict = {}
 
 class User(DAOModel, table=True):
-    username: Identifier[str]
+    username: Identifier[no_case_str]
     email: str = Field(unique=True)
     favorite_song: Optional[Song]
     date_joined: datetime = CurrentTimestampField
@@ -679,7 +693,6 @@ This functionality will be documented in a future page dedicated to model compar
 
 ## Next Steps
 
-**WORK IN PROGRESS**
-
-Now that you understand how to use DAOModel methods, check out the [advanced features](advanced_features.md)
-such as [Search](search.md) to learn more about what DAOModel can do.
+You now understand how to define [Models](model.md) as well as create a [DAO](dao.md) layer for said models.
+The next logical step is to create a [Service Layer](service.md) which will provide methods for interacting with your models.
+Continue to the next page to learn all about the BaseService offered by DAOModel.

--- a/tests/test_fields__inherited.py
+++ b/tests/test_fields__inherited.py
@@ -4,7 +4,7 @@ from uuid import UUID
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from daomodel.fields import Protected, Identifier, Unsearchable
+from daomodel.fields import Protected, Identifier, Unsearchable, no_case_str
 from daomodel.util import ensure_iter, names_of
 from tests.conftest import TestDAOFactory
 from tests.labeled_tests import labeled_tests
@@ -18,41 +18,49 @@ all_test_cases = {
     'dict': dict,
     'reference': BasicModel,
     'protected reference': Protected[BasicModel],
+    'no_case_str': no_case_str,
     'identifier field': Identifier[str],
     'identifier uuid': Identifier[UUID],
     # Note: dict cannot be an Identifier as it is not hashable
     'identifier reference': Identifier[BasicModel],
     'identifier protected reference': Identifier[Protected[BasicModel]],
+    'identifier no_case_str': Identifier[no_case_str],
     'optional field': Optional[str],
     'optional uuid': Optional[UUID],
     'optional dict': Optional[dict],
     'optional reference': Optional[BasicModel],
     'optional protected reference': Protected[Optional[BasicModel]],
+    'optional no_case_str': Optional[no_case_str],
     'unsearchable field': Unsearchable[str],
     'unsearchable uuid': Unsearchable[UUID],
     'unsearchable dict': Unsearchable[dict],
     'unsearchable reference': Unsearchable[BasicModel],
     'unsearchable protected reference': Unsearchable[Protected[BasicModel]],
+    'unsearchable no_case_str': Unsearchable[no_case_str],
     'identifier + optional field': Identifier[Optional[str]],
     'identifier + optional uuid': Identifier[Optional[UUID]],
     # Note: dict cannot be an Identifier as it is not hashable
     'identifier + optional reference': Identifier[Optional[BasicModel]],
     'identifier + optional protected reference': Identifier[Protected[Optional[BasicModel]]],
+    'identifier + optional no_case_str': Identifier[Optional[no_case_str]],
     'unsearchable + identifier field': Unsearchable[Identifier[str]],
     'unsearchable + identifier uuid': Unsearchable[Identifier[UUID]],
     # Note: dict cannot be an Identifier as it is not hashable
     'unsearchable + identifier reference': Unsearchable[Identifier[BasicModel]],
     'unsearchable + identifier protected reference': Unsearchable[Identifier[Protected[BasicModel]]],
+    'unsearchable + identifier no_case_str': Unsearchable[Identifier[no_case_str]],
     'unsearchable + optional field': Unsearchable[Optional[str]],
     'unsearchable + optional uuid': Unsearchable[Optional[UUID]],
     'unsearchable + optional dict': Unsearchable[Optional[dict]],
     'unsearchable + optional reference': Unsearchable[Optional[BasicModel]],
     'unsearchable + optional protected reference': Unsearchable[Protected[Optional[BasicModel]]],
+    'unsearchable + optional no_case_str': Unsearchable[Optional[no_case_str]],
     'unsearchable + identifier + optional field': Unsearchable[Identifier[Optional[str]]],
     'unsearchable + identifier + optional uuid': Unsearchable[Identifier[Optional[UUID]]],
     # Note: dict cannot be an Identifier as it is not hashable
     'unsearchable + identifier + optional reference': Unsearchable[Identifier[Optional[BasicModel]]],
-    'unsearchable + identifier + optional protected reference': Unsearchable[Identifier[Protected[Optional[BasicModel]]]]
+    'unsearchable + identifier + optional protected reference': Unsearchable[Identifier[Protected[Optional[BasicModel]]]],
+    'unsearchable + identifier + optional no_case_str': Unsearchable[Identifier[Optional[no_case_str]]]
 }
 
 
@@ -106,6 +114,17 @@ def test_inherited_reference(annotation: Any):
         dao.create_with(id=1, value=100, child_field='extended')
         entry = dao.find(id=1)
         assert entry.only().value == 100
+        assert entry.only().child_field == 'extended'
+
+
+@labeled_tests(get_test_cases('no_case_str'))
+def test_inherited_no_case_str(annotation: Any):
+    model_type = create_test_model(annotation, inherited=True)
+    with TestDAOFactory() as daos:
+        dao = daos[model_type]
+        dao.create_with(id=1, value='TeStVaLuE', child_field='extended')
+        entry = dao.find(id=1)
+        assert entry.only().value == 'TeStVaLuE'
         assert entry.only().child_field == 'extended'
 
 

--- a/tests/test_fields__types.py
+++ b/tests/test_fields__types.py
@@ -1,12 +1,8 @@
 from typing import Optional, Any
 from uuid import UUID
 
-import pytest
-from sqlalchemy.exc import IntegrityError
-from sqlmodel import Field
-
 from daomodel import DAOModel
-from daomodel.fields import Protected, Identifier
+from daomodel.fields import Identifier
 from tests.conftest import TestDAOFactory
 from tests.labeled_tests import labeled_tests
 from tests.model_factory import create_test_model
@@ -93,3 +89,17 @@ def test_reference__uuid(daos: TestDAOFactory):
 def test_reference__uuid__optional(daos: TestDAOFactory):
     daos[UUIDOptionalReferenceModel].create(1)
     daos.assert_in_db(UUIDOptionalReferenceModel, 1, other_id=None)
+
+
+@labeled_tests(get_test_cases('no_case_str', exclude='unsearchable'))
+def test_no_case_str(annotation: Any):
+    model_type = create_test_model(annotation)
+    with TestDAOFactory() as daos:
+        dao = daos[model_type]
+        dao.create_with(id=1, value='TeStVaLuE')
+
+        assert dao.find(value='testvalue').only().id == 1
+        assert dao.find(value='TESTVALUE').only().id == 1
+        assert dao.find(value='testValue').only().id == 1
+
+        assert dao.find(id=1).only().value == 'TeStVaLuE'


### PR DESCRIPTION
Added a type shortcut of no_case_str to be used on models. This will act as a str type but also indicate to the DB that the field value is case_insensitive. That means that for searches and unique checks, a lowercase value will be considered the same as an uppercase value. This is useful for fields such as 'email' where case does not matter.